### PR TITLE
Clean up @random_variable/@functional and fix AST pattern utils

### DIFF
--- a/ppls/beanmachine/robust_regression.py
+++ b/ppls/beanmachine/robust_regression.py
@@ -2,13 +2,10 @@
 import time
 from typing import Any, Dict, List, Tuple
 
+import beanmachine.ppl as bm
 import torch
 import torch.distributions as dist
 import torch.tensor as tensor
-from beanmachine.ppl.inference.single_site_ancestral_mh import (
-    SingleSiteAncestralMetropolisHastings,
-)
-from beanmachine.ppl.model.statistical_model import sample
 from torch import Tensor
 
 
@@ -42,23 +39,23 @@ class RobustRegressionModel(object):
         self.X = X
         self.Y = Y
 
-    @sample
+    @bm.random_variable
     def nu(self):
         return dist.Gamma(2.0, 0.1)
 
-    @sample
+    @bm.random_variable
     def sigma(self):
         return dist.Exponential(self.rate_sigma)
 
-    @sample
+    @bm.random_variable
     def alpha(self):
         return dist.Normal(0, self.scale_alpha)
 
-    @sample
+    @bm.random_variable
     def beta(self, k: int):
         return dist.Normal(self.loc_beta, self.scale_beta)
 
-    @sample
+    @bm.random_variable
     def y(self, i: int):
         # Compute X * Beta
         mean = self.alpha()
@@ -70,7 +67,7 @@ class RobustRegressionModel(object):
         dict_y = {self.y(i): self.Y[i] for i in range(self.N)}
         if self.inference_type == "mcmc":
             samples_beta = torch.zeros([self.num_samples, self.K])
-            mh = SingleSiteAncestralMetropolisHastings()
+            mh = bm.SingleSiteAncestralMetropolisHastings()
             start_time = time.time()
             samples = mh.infer(
                 [self.nu(), self.sigma(), self.alpha()]

--- a/ppls/beanmachine/seismic_location.py
+++ b/ppls/beanmachine/seismic_location.py
@@ -1,8 +1,8 @@
 import time
 from typing import Dict, List, Tuple
 
+import beanmachine.ppl as bm
 import torch.tensor as tensor
-from beanmachine.ppl.inference.compositional_infer import CompositionalInference
 from benchmarks.pplbench.ppls.beanmachine.seismic_projection_model import (
     SeismicProjectionModel,
 )
@@ -34,7 +34,7 @@ def obtain_posterior(data_train: Dict, args_dict: Dict, model) -> Tuple[List, Di
 
     start_time = time.time()
     model = SeismicProjectionModel()
-    mh = CompositionalInference({model.event: SingleSiteSeismicProposer()})
+    mh = bm.CompositionalInference({model.event: SingleSiteSeismicProposer()})
     elapsed_time_compile_beanmachine = time.time() - start_time
 
     obs = {

--- a/ppls/beanmachine/seismic_projection_model.py
+++ b/ppls/beanmachine/seismic_projection_model.py
@@ -1,8 +1,8 @@
+import beanmachine.ppl as bm
 import benchmarks.pplbench.models.seismic_location_util as seismic
 import torch
 import torch.distributions as dist
 import torch.tensor as tensor
-from beanmachine.ppl.model.statistical_model import sample
 from torch import Tensor
 
 
@@ -13,21 +13,21 @@ class SeismicProjectionModel(object):
         self.mu_k_z = 0
         self.mu_k_s = 0
 
-    @sample
+    @bm.random_variable
     def event(self):
         return seismic.StereographicProjectionUniform()
 
-    @sample
+    @bm.random_variable
     def event_magnitude(self):
         return seismic.FiniteExponential(3.0, 4.0, 6.0)
 
-    @sample
+    @bm.random_variable
     def theta_k(self):
         alpha = tensor([120, 5.2, 6.7]).unsqueeze(0).expand(10, 3)
         beta = tensor([118, 44, 7.5]).unsqueeze(0).expand(10, 3)
         return seismic.InverseGamma(alpha, beta)
 
-    @sample
+    @bm.random_variable
     def mu_k_d(self):
         mean = tensor([-10.4, 3.26, -0.0499])
         cov = tensor(
@@ -41,7 +41,7 @@ class SeismicProjectionModel(object):
         cov = cov.unsqueeze(0).expand(10, 3, 3)
         return dist.MultivariateNormal(mean, cov)
 
-    @sample
+    @bm.random_variable
     def is_detected(self):
         mu = self.mu_k_d()
 
@@ -58,7 +58,7 @@ class SeismicProjectionModel(object):
         )
         return dist.Bernoulli(detection_prob[1:])
 
-    @sample
+    @bm.random_variable
     def holdout_is_detected(self):
         mu = self.mu_k_d()
 
@@ -97,7 +97,7 @@ class SeismicProjectionModel(object):
             dim=1,
         )
 
-    @sample
+    @bm.random_variable
     def detection(self):
         mask = self.is_detected().expand(3, 9).transpose(0, 1)
         detection_loc = self.compute_detection_loc(self.event())


### PR DESCRIPTION
Summary:
Cleans up imports to use our blessed "bm" aliased top-level package, makes use of `random_variable` and `functional` instead of  `sample` and `query` (which are scheduled for deprecation).

This diff also affects the behavior of the AST pattern library: both `sample` and `whateveryoualiasedbeanmachinepplto.random_variable` now match for the corresponding AST rules

Differential Revision: D21745281

