### PR TITLE
Have all ppl implementations inherit from a standard PPL class (#119)

### DIFF
--- a/PPLBench.py
+++ b/PPLBench.py
@@ -3,6 +3,7 @@
 import argparse
 import datetime
 import importlib
+import inspect
 import os
 import pickle
 import pkgutil
@@ -17,6 +18,7 @@ import pandas as pd
 import ppls
 import torch
 import torch.tensor as tensor
+from ppls.pplbench_ppl import PPLBenchPPL
 from utils import effective_sample_size, split_r_hat
 
 
@@ -408,7 +410,7 @@ def main():
 
         # check if the ppl has a corresponding model implementation module
         try:
-            module = importlib.import_module(f"ppls.{ppl}.{args.model}")
+            ppl_module = importlib.import_module(f"ppls.{ppl}.{args.model}")
         except ModuleNotFoundError:
             traceback.print_exc()
             print(f"{ppl} implementation not found for {args.model}; exiting...")
@@ -429,7 +431,10 @@ def main():
             ppl, _ = ppls_args
         # check if the ppl has a corresponding model implementation module
         try:
-            module = importlib.import_module(f"ppls.{ppl}.{args.model}")
+            ppl_module = importlib.import_module(f"ppls.{ppl}.{args.model}")
+            for name, ppl_class in inspect.getmembers(ppl_module, inspect.isclass):
+                if issubclass(ppl_class, PPLBenchPPL) and name != "PPLBenchPPL":
+                    ppl_instance = ppl_class()
         except ModuleNotFoundError:
             continue
         print(f"{ppl}:")
@@ -440,7 +445,10 @@ def main():
         for i in range(int(args_dict["trials"])):
             print("Starting trial", i + 1, "of", args_dict["trials"])
             # obtain posterior samples and timing info
-            posterior_samples[ppl][i], timing_info[ppl][i] = module.obtain_posterior(
+            (
+                posterior_samples[ppl][i],
+                timing_info[ppl][i],
+            ) = ppl_instance.obtain_posterior(
                 data_train=generated_data["data_train"],
                 args_dict=args_dict,
                 model=model_instance,

--- a/ppls/beanmachine-vectorized/logistic_regression.py
+++ b/ppls/beanmachine-vectorized/logistic_regression.py
@@ -1,6 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates
 import time
-from typing import Any, Dict, List, Tuple
+from typing import Dict, List, Tuple
 
 import beanmachine.ppl as bm
 import numpy as np
@@ -9,9 +9,11 @@ import torch.distributions as dist
 import torch.tensor as tensor
 from torch import Tensor
 
+from ..pplbench_ppl import PPLBenchPPL
+
 
 """
-For model definition, see models/logisticRegressionModel.py
+For model definition, see models/logistic_regression_model.py
 """
 
 
@@ -65,64 +67,65 @@ class LogisticRegressionModel(object):
         return (samples, elapsed_time_sample_beanmachine)
 
 
-def obtain_posterior(
-    data_train: Tuple[Any, Any], args_dict: Dict, model: LogisticRegressionModel
-) -> Tuple[List, Dict]:
-    """
-    Beanmachine impmementation of logisitc regression model.
+class LogisticRegression(PPLBenchPPL):
+    def obtain_posterior(
+        self, data_train: Tuple[np.ndarray, np.ndarray], args_dict: Dict, model=None
+    ) -> Tuple[List, Dict]:
+        """
+        Beanmachine impmementation of logisitc regression model.
 
-    :param data_train: tuple of np.ndarray (x_train, y_train)
-    :param args_dict: a dict of model arguments
-    :returns: samples_beanmachine(dict): posterior samples of all parameters
-    :returns: timing_info(dict): compile_time, inference_time
-    """
-    # shape of x_train: (num_features, num_samples)
-    x_train, y_train = data_train
-    y_train = np.array(y_train, dtype=np.float32)
-    x_train = np.array(x_train, dtype=np.float32)
-    x_train = tensor(x_train)
-    y_train = tensor([tensor(y) for y in y_train])
-    N = int(x_train.shape[1])
-    K = int(x_train.shape[0])
+        :param data_train: tuple of np.ndarray (x_train, y_train)
+        :param args_dict: a dict of model arguments
+        :returns: samples_beanmachine(list of dict): posterior samples of all parameters
+        :returns: timing_info(dict): compile_time, inference_time
+        """
+        # shape of x_train: (num_features, num_samples)
+        x_train, y_train = data_train
+        y_train = np.array(y_train, dtype=np.float32)
+        x_train = np.array(x_train, dtype=np.float32)
+        x_train = tensor(x_train)
+        y_train = tensor([tensor(y) for y in y_train])
+        N = int(x_train.shape[1])
+        K = int(x_train.shape[0])
 
-    alpha_scale = float((args_dict["model_args"])[0])
-    beta_scale = [float((args_dict["model_args"])[1])] * K
-    beta_loc = float((args_dict["model_args"])[2])
-    num_samples = args_dict["num_samples_beanmachine-vectorized"]
-    inference_type = args_dict["inference_type"]
+        alpha_scale = float((args_dict["model_args"])[0])
+        beta_scale = [float((args_dict["model_args"])[1])] * K
+        beta_loc = float((args_dict["model_args"])[2])
+        num_samples = args_dict["num_samples_beanmachine-vectorized"]
+        inference_type = args_dict["inference_type"]
 
-    start_time = time.time()
-    logistic_regression_model = LogisticRegressionModel(
-        N,
-        K,
-        alpha_scale,
-        beta_scale,
-        beta_loc,
-        num_samples,
-        inference_type,
-        x_train,
-        y_train,
-    )
-    elapsed_time_compile_beanmachine = time.time() - start_time
-    samples, elapsed_time_sample_beanmachine = logistic_regression_model.infer()
+        start_time = time.time()
+        logistic_regression_model = LogisticRegressionModel(
+            N,
+            K,
+            alpha_scale,
+            beta_scale,
+            beta_loc,
+            num_samples,
+            inference_type,
+            x_train,
+            y_train,
+        )
+        elapsed_time_compile_beanmachine = time.time() - start_time
+        samples, elapsed_time_sample_beanmachine = logistic_regression_model.infer()
 
-    # repackage samples into format required by PPLBench
-    # List of dict, where each dict has key = param (string), value = value of param
-    param_keys = ["beta", "alpha"]
-    samples_formatted = []
-    for i in range(num_samples):
-        sample_dict = {}
-        for j, parameter in enumerate(samples.get_rv_names()):
-            sample_dict[param_keys[j]] = (
-                samples.get_variable(parameter)[i][1:].detach().numpy()
-            )
-            sample_dict[param_keys[1]] = (
-                samples.get_variable(parameter)[i][0].detach().numpy()
-            )
-        samples_formatted.append(sample_dict)
+        # repackage samples into format required by PPLBench
+        # List of dict, where each dict has key = param (string), value = value of param
+        param_keys = ["beta", "alpha"]
+        samples_formatted = []
+        for i in range(num_samples):
+            sample_dict = {}
+            for j, parameter in enumerate(samples.get_rv_names()):
+                sample_dict[param_keys[j]] = (
+                    samples.get_variable(parameter)[i][1:].detach().numpy()
+                )
+                sample_dict[param_keys[1]] = (
+                    samples.get_variable(parameter)[i][0].detach().numpy()
+                )
+            samples_formatted.append(sample_dict)
 
-    timing_info = {
-        "compile_time": elapsed_time_compile_beanmachine,
-        "inference_time": elapsed_time_sample_beanmachine,
-    }
-    return (samples_formatted, timing_info)
+        timing_info = {
+            "compile_time": elapsed_time_compile_beanmachine,
+            "inference_time": elapsed_time_sample_beanmachine,
+        }
+        return (samples_formatted, timing_info)

--- a/ppls/beanmachine-vectorized/robust_regression.py
+++ b/ppls/beanmachine-vectorized/robust_regression.py
@@ -1,16 +1,19 @@
 # Copyright (c) Facebook, Inc. and its affiliates
 import time
-from typing import Any, Dict, List, Tuple
+from typing import Dict, List, Tuple
 
 import beanmachine.ppl as bm
+import numpy as np
 import torch
 import torch.distributions as dist
 import torch.tensor as tensor
 from torch import Tensor
 
+from ..pplbench_ppl import PPLBenchPPL
+
 
 """
-For model definition, see models/robustRegressionModel.py
+For model definition, see models/robust_regression_model.py
 """
 
 
@@ -78,68 +81,69 @@ class RobustRegressionModel(object):
         return (samples, elapsed_time_sample_beanmachine)
 
 
-def obtain_posterior(
-    data_train: Tuple[Any, Any], args_dict: Dict, model: RobustRegressionModel
-) -> Tuple[List, Dict]:
-    """
-    Beanmachine impmementation of robust regression model.
+class RobustRegression(PPLBenchPPL):
+    def obtain_posterior(
+        self, data_train: Tuple[np.ndarray, np.ndarray], args_dict: Dict, model=None
+    ) -> Tuple[List, Dict]:
+        """
+        Beanmachine impmementation of robust regression model.
 
-    :param data_train: tuple of np.ndarray (x_train, y_train)
-    :param args_dict: a dict of model arguments
-    :returns: samples_beanmachine(dict): posterior samples of all parameters
-    :returns: timing_info(dict): compile_time, inference_time
-    """
-    # shape of x_train: (num_features, num_samples)
-    x_train, y_train = data_train
-    x_train = tensor(x_train, dtype=torch.float32)
-    y_train = tensor(y_train, dtype=torch.float32)
-    N = int(x_train.shape[1])
-    K = int(x_train.shape[0])
+        :param data_train: tuple of np.ndarray (x_train, y_train)
+        :param args_dict: a dict of model arguments
+        :returns: samples_beanmachine(dict): posterior samples of all parameters
+        :returns: timing_info(dict): compile_time, inference_time
+        """
+        # shape of x_train: (num_features, num_samples)
+        x_train, y_train = data_train
+        x_train = tensor(x_train, dtype=torch.float32)
+        y_train = tensor(y_train, dtype=torch.float32)
+        N = int(x_train.shape[1])
+        K = int(x_train.shape[0])
 
-    alpha_scale, beta_scale, beta_loc, sigma_mean = args_dict["model_args"]
-    beta_scale = [beta_scale] * K
-    num_samples = args_dict["num_samples_beanmachine-vectorized"]
-    inference_type = args_dict["inference_type"]
+        alpha_scale, beta_scale, beta_loc, sigma_mean = args_dict["model_args"]
+        beta_scale = [beta_scale] * K
+        num_samples = args_dict["num_samples_beanmachine-vectorized"]
+        inference_type = args_dict["inference_type"]
 
-    start_time = time.time()
-    robust_regression_model = RobustRegressionModel(
-        N,
-        K,
-        alpha_scale,
-        beta_scale,
-        beta_loc,
-        1.0 / sigma_mean,
-        num_samples,
-        inference_type,
-        x_train,
-        y_train,
-    )
-    elapsed_time_compile_beanmachine = time.time() - start_time
-    samples, elapsed_time_sample_beanmachine = robust_regression_model.infer()
+        start_time = time.time()
+        robust_regression_model = RobustRegressionModel(
+            N,
+            K,
+            alpha_scale,
+            beta_scale,
+            beta_loc,
+            1.0 / sigma_mean,
+            num_samples,
+            inference_type,
+            x_train,
+            y_train,
+        )
+        elapsed_time_compile_beanmachine = time.time() - start_time
+        samples, elapsed_time_sample_beanmachine = robust_regression_model.infer()
 
-    # repackage samples into format required by PPLBench
-    # List of dict, where each dict has key = param (string), value = value of param
-    param_keys = ["beta", "nu", "sigma"]
-    samples_formatted = []
-    for i in range(num_samples):
-        sample_dict = {}
-        for j, parameter in enumerate(samples.get_rv_names()):
-            if j == 0:
-                sample_dict[param_keys[j]] = (
-                    samples.get_variable(parameter)[i][1:]
-                    .detach()
-                    .numpy()
-                    .reshape(1, K)
-                )
-                sample_dict["alpha"] = (
-                    samples.get_variable(parameter)[i][0].detach().numpy()
-                )
-            else:
-                sample_dict[param_keys[j]] = samples[parameter][i].item()
-        samples_formatted.append(sample_dict)
+        # repackage samples into format required by PPLBench
+        # List of dict, where each dict has key = param (string), value = value of param
+        param_keys = ["beta", "nu", "sigma"]
+        samples_formatted = []
+        for i in range(num_samples):
+            sample_dict = {}
+            for j, parameter in enumerate(samples.get_rv_names()):
+                if j == 0:
+                    sample_dict[param_keys[j]] = (
+                        samples.get_variable(parameter)[i][1:]
+                        .detach()
+                        .numpy()
+                        .reshape(1, K)
+                    )
+                    sample_dict["alpha"] = (
+                        samples.get_variable(parameter)[i][0].detach().numpy()
+                    )
+                else:
+                    sample_dict[param_keys[j]] = samples[parameter][i].item()
+            samples_formatted.append(sample_dict)
 
-    timing_info = {
-        "compile_time": elapsed_time_compile_beanmachine,
-        "inference_time": elapsed_time_sample_beanmachine,
-    }
-    return (samples_formatted, timing_info)
+        timing_info = {
+            "compile_time": elapsed_time_compile_beanmachine,
+            "inference_time": elapsed_time_sample_beanmachine,
+        }
+        return (samples_formatted, timing_info)

--- a/ppls/beanmachine/crowd_sourced_annotation.py
+++ b/ppls/beanmachine/crowd_sourced_annotation.py
@@ -10,41 +10,7 @@ import torch.distributions as dist
 from beanmachine.ppl.inference.monte_carlo_samples import MonteCarloSamples
 from torch import tensor
 
-
-def format_data(Y_i: List, J_i: List, num_labels: List) -> Tuple[List, List]:
-    """
-    param: Y_i: List of all the labels produced by different labelers
-    param: J_i: List of the labelers that produced the respective label
-    param: num_labels: List representing number of labels for each item
-
-    Example:
-    Y_i = [1, 1, 1, 0, 2, 2, 1, 2, 1, 1, 1, 0, 0,
-        1, 1, 1, 0, 1, 1, 2, 0, 1, 1, 2, 0, 0, 2, 1]
-    J_i = [0, 7, 5, 1, 4, 9, 3, 8, 5, 3, 5, 9, 2,
-        4, 2, 6, 0, 9, 5, 8, 1, 9, 4, 8, 9, 0, 7, 5]
-    num_labels = [1, 4, 4, 2, 2, 3, 5, 1, 5, 1]
-
-    Returns:
-    [[1], [1, 1, 0, 2], [2, 1, 2, 1], [1, 1], [0, 0],
-    [1, 1, 1], [0, 1, 1, 2, 0], [1], [1, 2, 0, 0, 2], [1]]
-    [[0], [7, 5, 1, 4], [9, 3, 8, 5], [3, 5], [9, 2],
-    [4, 2, 6], [0, 9, 5, 8, 1], [9], [4, 8, 9, 0, 7], [5]]
-    """
-    Y_ij = []
-    J_ij = []
-    counter = 0
-    for i in range(len(num_labels)):
-        y = []
-        j = []
-        num_labelers = num_labels[i]
-        for _j in range(num_labelers):
-            y.append(Y_i[counter])
-            j.append(J_i[counter])
-            counter += 1
-
-        Y_ij.append(y)
-        J_ij.append(j)
-    return (Y_ij, J_ij)
+from ..pplbench_ppl import PPLBenchPPL
 
 
 class CrowdSourcedAnnotationModel(object):
@@ -127,61 +93,99 @@ class CrowdSourcedAnnotationModel(object):
         return (samples, elapsed_time_sample_beanmachine)
 
 
-def obtain_posterior(
-    data_train: Tuple[List, List, List],
-    args_dict: Dict,
-    model: CrowdSourcedAnnotationModel,
-) -> Tuple[List, Dict]:
-    """
-    Beanmachine impmementation of CLARA model.
+class CrowdSourcedAnnotation(PPLBenchPPL):
+    def format_data(
+        self, Y_i: List, J_i: List, num_labels: List, model=None
+    ) -> Tuple[List, List]:
+        """
+        param: Y_i: List of all the labels produced by different labelers
+        param: J_i: List of the labelers that produced the respective label
+        param: num_labels: List representing number of labels for each item
 
-    :param data_train: tuple of np.ndarray (y, J_i, num_labels)
-    :param args_dict: a dict of model arguments
-    :returns: samples_beanmachine(dict): posterior samples of all parameters
-    :returns: timing_info(dict): compile_time, inference_time
-    """
-    vector_y, vector_J_i, num_labels = data_train
-    Y_ij, J_ij = format_data(vector_y, vector_J_i, num_labels)
-    num_labelers = int(args_dict["k"])
-    num_items = len(num_labels)
-    num_categories, labeler_rate, expected_correctness, concentration = args_dict[
-        "model_args"
-    ]
-    iterations = args_dict["num_samples_beanmachine"]
-    inference_type = args_dict["inference_type"]
+        Example:
+        Y_i = [1, 1, 1, 0, 2, 2, 1, 2, 1, 1, 1, 0, 0,
+            1, 1, 1, 0, 1, 1, 2, 0, 1, 1, 2, 0, 0, 2, 1]
+        J_i = [0, 7, 5, 1, 4, 9, 3, 8, 5, 3, 5, 9, 2,
+            4, 2, 6, 0, 9, 5, 8, 1, 9, 4, 8, 9, 0, 7, 5]
+        num_labels = [1, 4, 4, 2, 2, 3, 5, 1, 5, 1]
 
-    crowdSourcedAnnotationModel = CrowdSourcedAnnotationModel(
-        expected_correctness,
-        concentration,
-        num_categories,
-        num_labelers,
-        num_items,
-        Y_ij,
-        J_ij,
-        iterations,
-        inference_type,
-    )
-    start_time = time.time()
-    samples, timing_info = crowdSourcedAnnotationModel.infer()
-    elapsed_time_beanmachine = time.time() - start_time
+        Returns:
+        [[1], [1, 1, 0, 2], [2, 1, 2, 1], [1, 1], [0, 0],
+        [1, 1, 1], [0, 1, 1, 2, 0], [1], [1, 2, 0, 0, 2], [1]]
+        [[0], [7, 5, 1, 4], [9, 3, 8, 5], [3, 5], [9, 2],
+        [4, 2, 6], [0, 9, 5, 8, 1], [9], [4, 8, 9, 0, 7], [5]]
+        """
+        Y_ij = []
+        J_ij = []
+        counter = 0
+        for i in range(len(num_labels)):
+            y = []
+            j = []
+            num_labelers = num_labels[i]
+            for _j in range(num_labelers):
+                y.append(Y_i[counter])
+                j.append(J_i[counter])
+                counter += 1
 
-    # repackage samples into shape required by PPLBench
-    samples_formatted = []
-    for i in range(args_dict["num_samples_beanmachine"]):
-        sample_dict = {}
-        sample_dict["pi"] = (
-            samples.get_variable(crowdSourcedAnnotationModel.pi())[i].detach().numpy()
+            Y_ij.append(y)
+            J_ij.append(j)
+        return (Y_ij, J_ij)
+
+    def obtain_posterior(
+        self, data_train: Tuple[List, List, List], args_dict: Dict, model=None
+    ) -> Tuple[List, Dict]:
+        """
+        Beanmachine impmementation of CLARA model.
+
+        :param data_train: tuple of np.ndarray (y, J_i, num_labels)
+        :param args_dict: a dict of model arguments
+        :returns: samples_beanmachine(dict): posterior samples of all parameters
+        :returns: timing_info(dict): compile_time, inference_time
+        """
+        vector_y, vector_J_i, num_labels = data_train
+        Y_ij, J_ij = self.format_data(vector_y, vector_J_i, num_labels)
+        num_labelers = int(args_dict["k"])
+        num_items = len(num_labels)
+        num_categories, labeler_rate, expected_correctness, concentration = args_dict[
+            "model_args"
+        ]
+        iterations = args_dict["num_samples_beanmachine"]
+        inference_type = args_dict["inference_type"]
+
+        crowdSourcedAnnotationModel = CrowdSourcedAnnotationModel(
+            expected_correctness,
+            concentration,
+            num_categories,
+            num_labelers,
+            num_items,
+            Y_ij,
+            J_ij,
+            iterations,
+            inference_type,
         )
-        theta = np.zeros((num_labelers, num_categories, num_categories))
-        for j in range(num_labelers):
-            for k in range(num_categories):
-                theta[j, k, :] = (
-                    samples.get_variable(crowdSourcedAnnotationModel.theta(j, k))[i]
-                    .detach()
-                    .numpy()
-                )
-        sample_dict["theta"] = theta
-        samples_formatted.append(sample_dict)
-    timing_info = {"compile_time": 0, "inference_time": elapsed_time_beanmachine}
+        start_time = time.time()
+        samples, timing_info = crowdSourcedAnnotationModel.infer()
+        elapsed_time_beanmachine = time.time() - start_time
 
-    return (samples_formatted, timing_info)
+        # repackage samples into shape required by PPLBench
+        samples_formatted = []
+        for i in range(args_dict["num_samples_beanmachine"]):
+            sample_dict = {}
+            sample_dict["pi"] = (
+                samples.get_variable(crowdSourcedAnnotationModel.pi())[i]
+                .detach()
+                .numpy()
+            )
+            theta = np.zeros((num_labelers, num_categories, num_categories))
+            for j in range(num_labelers):
+                for k in range(num_categories):
+                    theta[j, k, :] = (
+                        samples.get_variable(crowdSourcedAnnotationModel.theta(j, k))[i]
+                        .detach()
+                        .numpy()
+                    )
+            sample_dict["theta"] = theta
+            samples_formatted.append(sample_dict)
+        timing_info = {"compile_time": 0, "inference_time": elapsed_time_beanmachine}
+
+        return (samples_formatted, timing_info)

--- a/ppls/beanmachine/hidden_markov.py
+++ b/ppls/beanmachine/hidden_markov.py
@@ -8,6 +8,8 @@ import torch
 import torch.distributions as dist
 from torch import Tensor, tensor
 
+from ..pplbench_ppl import PPLBenchPPL
+
 
 class HiddenMarkovModel(object):
     def __init__(
@@ -111,64 +113,66 @@ class HiddenMarkovModel(object):
         return (samples, elapsed_time_sample_beanmachine)
 
 
-def obtain_posterior(
-    data_train: List, args_dict: Dict, model: Optional[Tensor]
-) -> Tuple[List, Dict]:
-    """
-    Beanmachine impmementation of HMM prediction.
+class HiddenMarkov(PPLBenchPPL):
+    def obtain_posterior(
+        self, data_train: List, args_dict: Dict, model: Optional[Tensor]
+    ) -> Tuple[List, Dict]:
+        """
+        Beanmachine impmementation of HMM prediction.
 
-    :param data_train:
-    :param args_dict: a dict of model arguments
-    :returns: samples_beanmachine(dict): posterior samples of all parameters
-    :returns: timing_info(dict): compile_time, inference_time
-    """
-    concentration, mu_loc, mu_scale, sigma_shape, sigma_rate, observe_model = list(
-        map(float, args_dict["model_args"])
-    )
-    N = int(args_dict["n"])
-    K = int(args_dict["k"])
-    num_samples = int(args_dict["num_samples"])
-    if not observe_model:
-        model = None
+        :param data_train:
+        :param args_dict: a dict of model arguments
+        :returns: samples_beanmachine(dict): posterior samples of all parameters
+        :returns: timing_info(dict): compile_time, inference_time
+        """
+        concentration, mu_loc, mu_scale, sigma_shape, sigma_rate, observe_model = list(
+            map(float, args_dict["model_args"])
+        )
+        N = int(args_dict["n"])
+        K = int(args_dict["k"])
+        num_samples = int(args_dict["num_samples"])
+        if not observe_model:
+            model = None
 
-    start_time = time.time()
-    # hmm = HiddenMarkovModel(N, K, theta, sigma, data_train, num_samples)
-    hmm = HiddenMarkovModel(
-        N,
-        K,
-        data_train,
-        num_samples,
-        concentration,
-        mu_loc,
-        mu_scale,
-        sigma_shape,
-        sigma_rate,
-        model,
-    )
-    elapsed_time_compile_beanmachine = time.time() - start_time
+        start_time = time.time()
+        # hmm = HiddenMarkovModel(N, K, theta, sigma, data_train, num_samples)
+        hmm = HiddenMarkovModel(
+            N,
+            K,
+            data_train,
+            num_samples,
+            concentration,
+            mu_loc,
+            mu_scale,
+            sigma_shape,
+            sigma_rate,
+            model,
+        )
+        elapsed_time_compile_beanmachine = time.time() - start_time
 
-    samples, elapsed_time_sample_beanmachine = hmm.infer()
+        samples, elapsed_time_sample_beanmachine = hmm.infer()
 
-    # repackage samples into shape required by PPLBench
-    xn1str = "X[" + str(N - 1) + "]"
-    if observe_model:
-        samples_formatted = [{xn1str: xn1} for xn1 in samples]
+        # repackage samples into shape required by PPLBench
+        xn1str = "X[" + str(N - 1) + "]"
+        if observe_model:
+            samples_formatted = [{xn1str: xn1} for xn1 in samples]
 
-    else:
-        thetas, mus, sigmas, xn1s = samples
-        # Want to swap the way these are ordered, so we can iterate through.
-        thetas = [[thetasK[i] for thetasK in thetas] for i in range(num_samples)]
-        mus = [[musK[i] for musK in mus] for i in range(num_samples)]
-        sigmas = [[sigmasK[i] for sigmasK in sigmas] for i in range(num_samples)]
-        # Now, e.g., thetas[i] gives the 'i'th MCMC sample of theta[0 .. K] as a list
+        else:
+            thetas, mus, sigmas, xn1s = samples
+            # Want to swap the way these are ordered, so we can iterate through.
+            thetas = [[thetasK[i] for thetasK in thetas] for i in range(num_samples)]
+            mus = [[musK[i] for musK in mus] for i in range(num_samples)]
+            sigmas = [[sigmasK[i] for sigmasK in sigmas] for i in range(num_samples)]
+            # Now, e.g., thetas[i] gives the 'i'th
+            # MCMC sample of theta[0 .. K] as a list
 
-        samples_formatted = [
-            {"theta": theta, "mus": mu, "sigmas": sigma, xn1str: xn1}
-            for theta, mu, sigma, xn1 in zip(thetas, mus, sigmas, xn1s)
-        ]
+            samples_formatted = [
+                {"theta": theta, "mus": mu, "sigmas": sigma, xn1str: xn1}
+                for theta, mu, sigma, xn1 in zip(thetas, mus, sigmas, xn1s)
+            ]
 
-    timing_info = {
-        "compile_time": elapsed_time_compile_beanmachine,
-        "inference_time": elapsed_time_sample_beanmachine,
-    }
-    return (samples_formatted, timing_info)
+        timing_info = {
+            "compile_time": elapsed_time_compile_beanmachine,
+            "inference_time": elapsed_time_sample_beanmachine,
+        }
+        return (samples_formatted, timing_info)

--- a/ppls/beanmachine/noisy_or_topic.py
+++ b/ppls/beanmachine/noisy_or_topic.py
@@ -6,6 +6,8 @@ import numpy as np
 import torch
 import torch.distributions as dist
 
+from ..pplbench_ppl import PPLBenchPPL
+
 
 class NoisyOrModel(object):
     def __init__(self, graph, words, T, iterations, inference_type):
@@ -52,40 +54,41 @@ class NoisyOrModel(object):
         return (samples, elapsed_time_sample_beanmachine)
 
 
-def obtain_posterior(data_train, args_dict, model):
-    """
-    Beanmachine impmementation of Noisy-Or Topic Model.
+class NoisyOrTopic(PPLBenchPPL):
+    def obtain_posterior(self, data_train, args_dict, model):
+        """
+        Beanmachine impmementation of Noisy-Or Topic Model.
 
-    Inputs:
-    - data_train(tuple of np.ndarray): graph, words
-    - args_dict: a dict of model arguments
-    Returns:
-    - samples_bm(dict): posterior samples of all parameters
-    - timing_info(dict): compile_time, inference_time
-    """
-    graph = model
-    words = data_train
-    words = torch.Tensor(words)
+        Inputs:
+        - data_train(tuple of np.ndarray): graph, words
+        - args_dict: a dict of model arguments
+        Returns:
+        - samples_bm(dict): posterior samples of all parameters
+        - timing_info(dict): compile_time, inference_time
+        """
+        graph = model
+        words = data_train
+        words = torch.Tensor(words)
 
-    K = int(args_dict["k"])
-    word_fraction = (args_dict["model_args"])[3]
-    T = int(K * (1 - word_fraction))
-    iterations = int(args_dict["num_samples_beanmachine"])
-    inference_type = args_dict["inference_type"]
-    assert len(words.shape) == 1
+        K = int(args_dict["k"])
+        word_fraction = (args_dict["model_args"])[3]
+        T = int(K * (1 - word_fraction))
+        iterations = int(args_dict["num_samples_beanmachine"])
+        inference_type = args_dict["inference_type"]
+        assert len(words.shape) == 1
 
-    noisy_or_model = NoisyOrModel(graph, words, T, iterations, inference_type)
-    samples, elapsed_time_bm = noisy_or_model.infer()
-    # repackage samples into format required by PPLBench
+        noisy_or_model = NoisyOrModel(graph, words, T, iterations, inference_type)
+        samples, elapsed_time_bm = noisy_or_model.infer()
+        # repackage samples into format required by PPLBench
 
-    samples_formatted = []
-    all_node_samples = np.zeros((iterations, T))
-    for t in range(1, T):
-        all_node_samples[:, t] = samples[noisy_or_model.node(t)].detach().numpy()
-    all_node_samples[:, 0] = 1.0
-    for i in range(iterations):
-        sample_dict = {}
-        sample_dict["node"] = all_node_samples[i]
-        samples_formatted.append(sample_dict)
-    timing_info = {"compile_time": 0, "inference_time": elapsed_time_bm}
-    return (samples_formatted, timing_info)
+        samples_formatted = []
+        all_node_samples = np.zeros((iterations, T))
+        for t in range(1, T):
+            all_node_samples[:, t] = samples[noisy_or_model.node(t)].detach().numpy()
+        all_node_samples[:, 0] = 1.0
+        for i in range(iterations):
+            sample_dict = {}
+            sample_dict["node"] = all_node_samples[i]
+            samples_formatted.append(sample_dict)
+        timing_info = {"compile_time": 0, "inference_time": elapsed_time_bm}
+        return (samples_formatted, timing_info)

--- a/ppls/beanmachine/robust_regression.py
+++ b/ppls/beanmachine/robust_regression.py
@@ -1,16 +1,19 @@
 # Copyright (c) Facebook, Inc. and its affiliates
 import time
-from typing import Any, Dict, List, Tuple
+from typing import Dict, List, Tuple
 
 import beanmachine.ppl as bm
+import numpy as np
 import torch
 import torch.distributions as dist
 import torch.tensor as tensor
 from torch import Tensor
 
+from ..pplbench_ppl import PPLBenchPPL
+
 
 """
-For model definition, see models/robustRegressionModel.py
+For model definition, see models/robust_regression_model.py
 """
 
 
@@ -87,62 +90,63 @@ class RobustRegressionModel(object):
         return (samples_beta.detach().numpy(), samples, elapsed_time_sample_beanmachine)
 
 
-def obtain_posterior(
-    data_train: Tuple[Any, Any], args_dict: Dict, model: RobustRegressionModel
-) -> Tuple[List, Dict]:
-    """
-    Beanmachine impmementation of robust regression model.
+class RobustRegression(PPLBenchPPL):
+    def obtain_posterior(
+        self, data_train: Tuple[np.ndarray, np.ndarray], args_dict: Dict, model=None
+    ) -> Tuple[List, Dict]:
+        """
+        Beanmachine impmementation of robust regression model.
 
-    :param data_train: tuple of np.ndarray (x_train, y_train)
-    :param args_dict: a dict of model arguments
-    :returns: samples_beanmachine(dict): posterior samples of all parameters
-    :returns: timing_info(dict): compile_time, inference_time
-    """
-    # shape of x_train: (num_features, num_samples)
-    x_train, y_train = data_train
-    y_train = [tensor(y) for y in y_train]
-    N = int(x_train.shape[1])
-    K = int(x_train.shape[0])
+        :param data_train: tuple of np.ndarray (x_train, y_train)
+        :param args_dict: a dict of model arguments
+        :returns: samples_beanmachine(dict): posterior samples of all parameters
+        :returns: timing_info(dict): compile_time, inference_time
+        """
+        # shape of x_train: (num_features, num_samples)
+        x_train, y_train = data_train
+        y_train = [tensor(y) for y in y_train]
+        N = int(x_train.shape[1])
+        K = int(x_train.shape[0])
 
-    alpha_scale, beta_scale, beta_loc, sigma_mean = args_dict["model_args"]
-    num_samples = args_dict["num_samples_beanmachine"]
-    inference_type = args_dict["inference_type"]
+        alpha_scale, beta_scale, beta_loc, sigma_mean = args_dict["model_args"]
+        num_samples = args_dict["num_samples_beanmachine"]
+        inference_type = args_dict["inference_type"]
 
-    start_time = time.time()
-    robust_regression_model = RobustRegressionModel(
-        N,
-        K,
-        alpha_scale,
-        beta_scale,
-        beta_loc,
-        1.0 / sigma_mean,
-        num_samples,
-        inference_type,
-        Tensor(x_train),
-        Tensor(y_train),
-    )
-    elapsed_time_compile_beanmachine = time.time() - start_time
-    (
-        samples_beta,
-        samples,
-        elapsed_time_sample_beanmachine,
-    ) = robust_regression_model.infer()
+        start_time = time.time()
+        robust_regression_model = RobustRegressionModel(
+            N,
+            K,
+            alpha_scale,
+            beta_scale,
+            beta_loc,
+            1.0 / sigma_mean,
+            num_samples,
+            inference_type,
+            Tensor(x_train),
+            Tensor(y_train),
+        )
+        elapsed_time_compile_beanmachine = time.time() - start_time
+        (
+            samples_beta,
+            samples,
+            elapsed_time_sample_beanmachine,
+        ) = robust_regression_model.infer()
 
-    # repackage samples into format required by PPLBench
-    # List of dict, where each dict has key = param (string), value = value of param
-    param_keys = ["nu", "sigma", "alpha"]
-    samples_formatted = []
-    for i in range(num_samples):
-        sample_dict = {}
-        sample_dict["beta"] = samples_beta[i]
-        for j, parameter in enumerate(samples.get_rv_names()):
-            if j >= len(param_keys):
-                break
-            sample_dict[param_keys[j]] = samples.get_variable(parameter)[i].item()
-        samples_formatted.append(sample_dict)
+        # repackage samples into format required by PPLBench
+        # List of dict, where each dict has key = param (string), value = value of param
+        param_keys = ["nu", "sigma", "alpha"]
+        samples_formatted = []
+        for i in range(num_samples):
+            sample_dict = {}
+            sample_dict["beta"] = samples_beta[i]
+            for j, parameter in enumerate(samples.get_rv_names()):
+                if j >= len(param_keys):
+                    break
+                sample_dict[param_keys[j]] = samples.get_variable(parameter)[i].item()
+            samples_formatted.append(sample_dict)
 
-    timing_info = {
-        "compile_time": elapsed_time_compile_beanmachine,
-        "inference_time": elapsed_time_sample_beanmachine,
-    }
-    return (samples_formatted, timing_info)
+        timing_info = {
+            "compile_time": elapsed_time_compile_beanmachine,
+            "inference_time": elapsed_time_sample_beanmachine,
+        }
+        return (samples_formatted, timing_info)

--- a/ppls/beanmachine/seismic_location.py
+++ b/ppls/beanmachine/seismic_location.py
@@ -11,58 +11,62 @@ from benchmarks.pplbench.ppls.beanmachine.seismic_projection_model import (
 from benchmarks.pplbench.ppls.beanmachine.seismic_proposer import (
     SingleSiteSeismicProposer,
 )
+from ppls.pplbench_ppl import PPLBenchPPL
 
 
-def obtain_posterior(data_train: Dict, args_dict: Dict, model) -> Tuple[List, Dict]:
-    """
-    Obtain samples using beanmachine
+class SeismicLocation(PPLBenchPPL):
+    def obtain_posterior(
+        self, data_train: Dict, args_dict: Dict, model
+    ) -> Tuple[List, Dict]:
+        """
+        Obtain samples using beanmachine
 
-    :param args_dict: arguments dictionary
-    :param model: dictionary with
-        mu(int) = detection probability properties per station
-        theta_k(int) = detection properties per station
-    :returns: generated_data(dict) = {
-        data_train: {
-            is_detected: is_detected for stations 1-9,
-            detection: detection for stations 1-9
-        data_test: {
-            detection_zero: detection for station 0
+        :param args_dict: arguments dictionary
+        :param model: dictionary with
+            mu(int) = detection probability properties per station
+            theta_k(int) = detection properties per station
+        :returns: generated_data(dict) = {
+            data_train: {
+                is_detected: is_detected for stations 1-9,
+                detection: detection for stations 1-9
+            data_test: {
+                detection_zero: detection for station 0
+            }
+        """
+        model_is_detected = data_train["is_detected"]
+        model_detection = data_train["detection"]
+        mu = model["mu"]
+        theta_k = model["theta_k"]
+
+        start_time = time.time()
+        model = SeismicProjectionModel()
+        mh = bm.CompositionalInference({model.event: SingleSiteSeismicProposer()})
+        elapsed_time_compile_beanmachine = time.time() - start_time
+
+        obs = {
+            model.holdout_is_detected(): tensor(1.0),
+            model.is_detected(): model_is_detected,
+            model.detection(): model_detection,
+            model.theta_k(): theta_k,
+            model.mu_k_d(): mu,
         }
-    """
-    model_is_detected = data_train["is_detected"]
-    model_detection = data_train["detection"]
-    mu = model["mu"]
-    theta_k = model["theta_k"]
 
-    start_time = time.time()
-    model = SeismicProjectionModel()
-    mh = bm.CompositionalInference({model.event: SingleSiteSeismicProposer()})
-    elapsed_time_compile_beanmachine = time.time() - start_time
+        query = [model.event(), model.event_magnitude()]
+        num_samples = args_dict["num_samples_beanmachine"]
 
-    obs = {
-        model.holdout_is_detected(): tensor(1.0),
-        model.is_detected(): model_is_detected,
-        model.detection(): model_detection,
-        model.theta_k(): theta_k,
-        model.mu_k_d(): mu,
-    }
+        start_time = time.time()
+        mh_infer = mh.infer(query, obs, num_samples, 1)
+        elapsed_time_sample_beanmachine = time.time() - start_time
 
-    query = [model.event(), model.event_magnitude()]
-    num_samples = args_dict["num_samples_beanmachine"]
+        mag = mh_infer[model.event_magnitude()].squeeze().detach()
+        event = mh_infer[model.event()].squeeze().detach()
 
-    start_time = time.time()
-    mh_infer = mh.infer(query, obs, num_samples, 1)
-    elapsed_time_sample_beanmachine = time.time() - start_time
+        samples = []
+        for i in range(num_samples):
+            samples.append((event[i], mag[i]))
 
-    mag = mh_infer[model.event_magnitude()].squeeze().detach()
-    event = mh_infer[model.event()].squeeze().detach()
-
-    samples = []
-    for i in range(num_samples):
-        samples.append((event[i], mag[i]))
-
-    timing_info = {
-        "compile_time": elapsed_time_compile_beanmachine,
-        "inference_time": elapsed_time_sample_beanmachine,
-    }
-    return (samples, timing_info)
+        timing_info = {
+            "compile_time": elapsed_time_compile_beanmachine,
+            "inference_time": elapsed_time_sample_beanmachine,
+        }
+        return (samples, timing_info)

--- a/ppls/bmgraph/logistic_regression.py
+++ b/ppls/bmgraph/logistic_regression.py
@@ -11,81 +11,90 @@ from typing import Any, Dict, List, Tuple
 import beanmachine.graph as bmgraph
 import numpy as np
 
+from ..pplbench_ppl import PPLBenchPPL
 
-def obtain_posterior(
-    data_train: Tuple[Any, Any], args_dict: Dict, model
-) -> Tuple[List, Dict]:
-    """
-    Beanmachine impmementation of logisitc regression model.
 
-    :param data_train: tuple of np.ndarray (x_train, y_train)
-    :param args_dict: a dict of model arguments
-    :returns: samples_beanmachine(dict): posterior samples of all parameters
-    :returns: timing_info(dict): compile_time, inference_time
-    """
-    x_train, y_train = data_train
-    K, N = x_train.shape  # K = num features, N = num observations
-    assert y_train.shape == (N,)
-    assert model is None
-    num_samples = int(args_dict["num_samples"])
-    alpha_scale, beta_scale, beta_loc, _ = args_dict["model_args"]
-    # compile the model
-    compile_start = time.time()
-    g = bmgraph.Graph()
-    # alpha ~ Normal(0, alpha_scale)
-    zero = g.add_constant(0.0)
-    alpha_scale = g.add_constant_pos_real(float(alpha_scale))
-    alpha_prior = g.add_distribution(
-        bmgraph.DistributionType.NORMAL, bmgraph.AtomicType.REAL, [zero, alpha_scale]
-    )
-    alpha = g.add_operator(bmgraph.OperatorType.SAMPLE, [alpha_prior])
-    # beta_j ~ Normal(beta_loc, beta_scale) for j in range(K)
-    beta_scale = g.add_constant_pos_real(float(beta_scale))
-    beta_loc = g.add_constant(float(beta_loc))
-    beta_prior = g.add_distribution(
-        bmgraph.DistributionType.NORMAL, bmgraph.AtomicType.REAL, [beta_loc, beta_scale]
-    )
-    beta = [g.add_operator(bmgraph.OperatorType.SAMPLE, [beta_prior]) for _ in range(K)]
-    # yhat_i = alpha + sum(x_j_i * beta_j for j in range(K))
-    for i in range(N):
-        sum_i = []
-        for j in range(K):
-            x_j_i = g.add_constant(float(x_train[j, i]))
-            x_j_i_times_beta_j = g.add_operator(
-                bmgraph.OperatorType.MULTIPLY, [x_j_i, beta[j]]
-            )
-            sum_i.append(x_j_i_times_beta_j)
-        sum_i.append(alpha)
-        yhat_i = g.add_operator(bmgraph.OperatorType.ADD, sum_i)
-        # y_i ~ Bernoulli(logit = yhat_i)
-        bernoulli_i = g.add_distribution(
-            bmgraph.DistributionType.BERNOULLI_LOGIT,
-            bmgraph.AtomicType.BOOLEAN,
-            [yhat_i],
+class LogisticRegression(PPLBenchPPL):
+    def obtain_posterior(
+        self, data_train: Tuple[Any, Any], args_dict: Dict, model
+    ) -> Tuple[List, Dict]:
+        """
+        Beanmachine impmementation of logisitc regression model.
+
+        :param data_train: tuple of np.ndarray (x_train, y_train)
+        :param args_dict: a dict of model arguments
+        :returns: samples_beanmachine(dict): posterior samples of all parameters
+        :returns: timing_info(dict): compile_time, inference_time
+        """
+        x_train, y_train = data_train
+        K, N = x_train.shape  # K = num features, N = num observations
+        assert y_train.shape == (N,)
+        assert model is None
+        num_samples = int(args_dict["num_samples"])
+        alpha_scale, beta_scale, beta_loc, _ = args_dict["model_args"]
+        # compile the model
+        compile_start = time.time()
+        g = bmgraph.Graph()
+        # alpha ~ Normal(0, alpha_scale)
+        zero = g.add_constant(0.0)
+        alpha_scale = g.add_constant_pos_real(float(alpha_scale))
+        alpha_prior = g.add_distribution(
+            bmgraph.DistributionType.NORMAL,
+            bmgraph.AtomicType.REAL,
+            [zero, alpha_scale],
         )
-        y_i = g.add_operator(bmgraph.OperatorType.SAMPLE, [bernoulli_i])
-        g.observe(y_i, bool(y_train[i]))
-    # We want P (alpha, beta_j for j in range(K) | x_i, y_i  for i in range(N))
-    g.query(alpha)
-    for j in range(K):
-        g.query(beta[j])
-    # we will include the inference time for one sample into the compile time
-    # and subtract this from inference time later
-    infer_setup_start = time.time()
-    g.infer(1, bmgraph.InferenceType.NMC)
-    infer_setup_time = time.time() - infer_setup_start
-    compile_time = time.time() - compile_start
-    infer_start = time.time()
-    samples = g.infer(
-        num_samples, bmgraph.InferenceType.NMC, int(time.time() * 1000) % 2 ** 31
-    )
-    infer_time = time.time() - infer_start - infer_setup_time
-    timing_info = {"compile_time": compile_time, "inference_time": infer_time}
-    print(f"bmgraph inference time {infer_time:.1f}")
-    sample_dicts = []
-    for sample in samples:
-        dict_ = {}
-        dict_["alpha"] = sample[0]
-        dict_["beta"] = np.array(sample[1:])
-        sample_dicts.append(dict_)
-    return sample_dicts, timing_info
+        alpha = g.add_operator(bmgraph.OperatorType.SAMPLE, [alpha_prior])
+        # beta_j ~ Normal(beta_loc, beta_scale) for j in range(K)
+        beta_scale = g.add_constant_pos_real(float(beta_scale))
+        beta_loc = g.add_constant(float(beta_loc))
+        beta_prior = g.add_distribution(
+            bmgraph.DistributionType.NORMAL,
+            bmgraph.AtomicType.REAL,
+            [beta_loc, beta_scale],
+        )
+        beta = [
+            g.add_operator(bmgraph.OperatorType.SAMPLE, [beta_prior]) for _ in range(K)
+        ]
+        # yhat_i = alpha + sum(x_j_i * beta_j for j in range(K))
+        for i in range(N):
+            sum_i = []
+            for j in range(K):
+                x_j_i = g.add_constant(float(x_train[j, i]))
+                x_j_i_times_beta_j = g.add_operator(
+                    bmgraph.OperatorType.MULTIPLY, [x_j_i, beta[j]]
+                )
+                sum_i.append(x_j_i_times_beta_j)
+            sum_i.append(alpha)
+            yhat_i = g.add_operator(bmgraph.OperatorType.ADD, sum_i)
+            # y_i ~ Bernoulli(logit = yhat_i)
+            bernoulli_i = g.add_distribution(
+                bmgraph.DistributionType.BERNOULLI_LOGIT,
+                bmgraph.AtomicType.BOOLEAN,
+                [yhat_i],
+            )
+            y_i = g.add_operator(bmgraph.OperatorType.SAMPLE, [bernoulli_i])
+            g.observe(y_i, bool(y_train[i]))
+        # We want P (alpha, beta_j for j in range(K) | x_i, y_i  for i in range(N))
+        g.query(alpha)
+        for j in range(K):
+            g.query(beta[j])
+        # we will include the inference time for one sample into the compile time
+        # and subtract this from inference time later
+        infer_setup_start = time.time()
+        g.infer(1, bmgraph.InferenceType.NMC)
+        infer_setup_time = time.time() - infer_setup_start
+        compile_time = time.time() - compile_start
+        infer_start = time.time()
+        samples = g.infer(
+            num_samples, bmgraph.InferenceType.NMC, int(time.time() * 1000) % 2 ** 31
+        )
+        infer_time = time.time() - infer_start - infer_setup_time
+        timing_info = {"compile_time": compile_time, "inference_time": infer_time}
+        print(f"bmgraph inference time {infer_time:.1f}")
+        sample_dicts = []
+        for sample in samples:
+            dict_ = {}
+            dict_["alpha"] = sample[0]
+            dict_["beta"] = np.array(sample[1:])
+            sample_dicts.append(dict_)
+        return sample_dicts, timing_info

--- a/ppls/bmgraph/n_schools.py
+++ b/ppls/bmgraph/n_schools.py
@@ -12,96 +12,101 @@ import beanmachine.graph as bmg
 import numpy as np
 import pandas as pd
 
+from ..pplbench_ppl import PPLBenchPPL
 
-def obtain_posterior(
-    data_train: Tuple[Any, Any], args_dict: Dict, model
-) -> Tuple[List, Dict]:
-    num_states, num_districts, num_types = [int(x) for x in args_dict["model_args"]]
-    compile_start = time.time()
-    g = bmg.Graph()
-    nodeidx = {}  # record the node ids of the latent variables
-    queryidx = {}  # also the query index of the latent variables
 
-    # beta_0 ~ StudentT(3, 0, 10)
-    three = g.add_constant_pos_real(3.0)
-    zero = g.add_constant(0.0)
-    ten = g.add_constant_pos_real(10.0)
-    beta_0_prior = g.add_distribution(
-        bmg.DistributionType.STUDENT_T, bmg.AtomicType.REAL, [three, zero, ten]
-    )
-    nodeidx["beta_0"] = g.add_operator(bmg.OperatorType.SAMPLE, [beta_0_prior])
+class NSchools(PPLBenchPPL):
+    def obtain_posterior(
+        self, data_train: Tuple[Any, Any], args_dict: Dict, model
+    ) -> Tuple[List, Dict]:
+        num_states, num_districts, num_types = [int(x) for x in args_dict["model_args"]]
+        compile_start = time.time()
+        g = bmg.Graph()
+        nodeidx = {}  # record the node ids of the latent variables
+        queryidx = {}  # also the query index of the latent variables
 
-    # sd_state ~ HalfCauchy(1)
-    # sd_district ~ HalfCauchy(1)
-    # sd_type ~ HalfCauchy(1)
-    one = g.add_constant_pos_real(1.0)
-    sd_prior = g.add_distribution(
-        bmg.DistributionType.HALF_CAUCHY, bmg.AtomicType.POS_REAL, [one]
-    )
-    sd_state = g.add_operator(bmg.OperatorType.SAMPLE, [sd_prior])
-    sd_district = g.add_operator(bmg.OperatorType.SAMPLE, [sd_prior])
-    sd_type = g.add_operator(bmg.OperatorType.SAMPLE, [sd_prior])
-    nodeidx["sd_state"] = sd_state
-    nodeidx["sd_district"] = sd_district
-    nodeidx["sd_type"] = sd_type
-
-    # beta_state[i] ~ Normal(0, sd_state)
-    # best_district[i, j] ~ Normal(0, sd_district)
-    beta_state_prior = g.add_distribution(
-        bmg.DistributionType.NORMAL, bmg.AtomicType.REAL, [zero, sd_state]
-    )
-    beta_district_prior = g.add_distribution(
-        bmg.DistributionType.NORMAL, bmg.AtomicType.REAL, [zero, sd_district]
-    )
-    for state in range(num_states):
-        nodeidx[f"beta_state_{state}"] = g.add_operator(
-            bmg.OperatorType.SAMPLE, [beta_state_prior]
+        # beta_0 ~ StudentT(3, 0, 10)
+        three = g.add_constant_pos_real(3.0)
+        zero = g.add_constant(0.0)
+        ten = g.add_constant_pos_real(10.0)
+        beta_0_prior = g.add_distribution(
+            bmg.DistributionType.STUDENT_T, bmg.AtomicType.REAL, [three, zero, ten]
         )
-        for district in range(num_districts):
-            nodeidx[f"beta_state_{state}_district_{district}"] = g.add_operator(
-                bmg.OperatorType.SAMPLE, [beta_district_prior]
+        nodeidx["beta_0"] = g.add_operator(bmg.OperatorType.SAMPLE, [beta_0_prior])
+
+        # sd_state ~ HalfCauchy(1)
+        # sd_district ~ HalfCauchy(1)
+        # sd_type ~ HalfCauchy(1)
+        one = g.add_constant_pos_real(1.0)
+        sd_prior = g.add_distribution(
+            bmg.DistributionType.HALF_CAUCHY, bmg.AtomicType.POS_REAL, [one]
+        )
+        sd_state = g.add_operator(bmg.OperatorType.SAMPLE, [sd_prior])
+        sd_district = g.add_operator(bmg.OperatorType.SAMPLE, [sd_prior])
+        sd_type = g.add_operator(bmg.OperatorType.SAMPLE, [sd_prior])
+        nodeidx["sd_state"] = sd_state
+        nodeidx["sd_district"] = sd_district
+        nodeidx["sd_type"] = sd_type
+
+        # beta_state[i] ~ Normal(0, sd_state)
+        # best_district[i, j] ~ Normal(0, sd_district)
+        beta_state_prior = g.add_distribution(
+            bmg.DistributionType.NORMAL, bmg.AtomicType.REAL, [zero, sd_state]
+        )
+        beta_district_prior = g.add_distribution(
+            bmg.DistributionType.NORMAL, bmg.AtomicType.REAL, [zero, sd_district]
+        )
+        for state in range(num_states):
+            nodeidx[f"beta_state_{state}"] = g.add_operator(
+                bmg.OperatorType.SAMPLE, [beta_state_prior]
             )
-    for type_ in range(num_types):
-        beta_type_prior = g.add_distribution(
-            bmg.DistributionType.NORMAL, bmg.AtomicType.REAL, [zero, sd_type]
+            for district in range(num_districts):
+                nodeidx[f"beta_state_{state}_district_{district}"] = g.add_operator(
+                    bmg.OperatorType.SAMPLE, [beta_district_prior]
+                )
+        for type_ in range(num_types):
+            beta_type_prior = g.add_distribution(
+                bmg.DistributionType.NORMAL, bmg.AtomicType.REAL, [zero, sd_type]
+            )
+            nodeidx[f"beta_type_{type_}"] = g.add_operator(
+                bmg.OperatorType.SAMPLE, [beta_type_prior]
+            )
+
+        # yhat[n] = beta_0 + beta_state[i[n]] + beta_district[i[n], j[n]] + beta_type[k[n]]
+        # y[n] ~ N(yhat[n], sei[n])
+        for _, row in data_train.iterrows():
+            yhat = g.add_operator(
+                bmg.OperatorType.ADD,
+                [
+                    nodeidx["beta_0"],
+                    nodeidx[f"beta_state_{row.state}"],
+                    nodeidx[f"beta_state_{row.state}_district_{row.district}"],
+                    nodeidx[f"beta_type_{row.type}"],
+                ],
+            )
+            sei = g.add_constant_pos_real(row.sei)
+            y_prior = g.add_distribution(
+                bmg.DistributionType.NORMAL, bmg.AtomicType.REAL, [yhat, sei]
+            )
+            y = g.add_operator(bmg.OperatorType.SAMPLE, [y_prior])
+            g.observe(y, row.yi)
+
+        # query all the beta_... nodes and the sd_.. nodes
+        for nodename, nodeid in nodeidx.items():
+            queryidx[nodename] = g.query(nodeid)
+
+        compile_time = time.time() - compile_start
+        infer_start = time.time()
+        seed = np.random.randint(1000, 1000000)
+        samples = np.array(
+            g.infer(args_dict["num_samples"], bmg.InferenceType.NMC, seed)
         )
-        nodeidx[f"beta_type_{type_}"] = g.add_operator(
-            bmg.OperatorType.SAMPLE, [beta_type_prior]
-        )
+        infer_time = time.time() - infer_start
+        timing_info = {"compile_time": compile_time, "inference_time": infer_time}
 
-    # yhat[n] = beta_0 + beta_state[i[n]] + beta_district[i[n], j[n]] + beta_type[k[n]]
-    # y[n] ~ N(yhat[n], sei[n])
-    for _, row in data_train.iterrows():
-        yhat = g.add_operator(
-            bmg.OperatorType.ADD,
-            [
-                nodeidx["beta_0"],
-                nodeidx[f"beta_state_{row.state}"],
-                nodeidx[f"beta_state_{row.state}_district_{row.district}"],
-                nodeidx[f"beta_type_{row.type}"],
-            ],
-        )
-        sei = g.add_constant_pos_real(row.sei)
-        y_prior = g.add_distribution(
-            bmg.DistributionType.NORMAL, bmg.AtomicType.REAL, [yhat, sei]
-        )
-        y = g.add_operator(bmg.OperatorType.SAMPLE, [y_prior])
-        g.observe(y, row.yi)
+        sample_dataframe = pd.DataFrame()
+        for nodename, queryid in queryidx.items():
+            sample_dataframe[nodename] = samples[:, queryid]
+        print(f"bmgraph inference time {infer_time:.1f}")
 
-    # query all the beta_... nodes and the sd_.. nodes
-    for nodename, nodeid in nodeidx.items():
-        queryidx[nodename] = g.query(nodeid)
-
-    compile_time = time.time() - compile_start
-    infer_start = time.time()
-    seed = np.random.randint(1000, 1000000)
-    samples = np.array(g.infer(args_dict["num_samples"], bmg.InferenceType.NMC, seed))
-    infer_time = time.time() - infer_start
-    timing_info = {"compile_time": compile_time, "inference_time": infer_time}
-
-    sample_dataframe = pd.DataFrame()
-    for nodename, queryid in queryidx.items():
-        sample_dataframe[nodename] = samples[:, queryid]
-    print(f"bmgraph inference time {infer_time:.1f}")
-
-    return sample_dataframe, timing_info
+        return sample_dataframe, timing_info

--- a/ppls/bmgraph/robust_regression.py
+++ b/ppls/bmgraph/robust_regression.py
@@ -11,102 +11,111 @@ from typing import Any, Dict, List, Tuple
 import beanmachine.graph as bmgraph
 import numpy as np
 
+from ..pplbench_ppl import PPLBenchPPL
 
-def obtain_posterior(
-    data_train: Tuple[Any, Any], args_dict: Dict, model
-) -> Tuple[List, Dict]:
-    """
-    Beanmachine impmementation of logisitc regression model.
 
-    :param data_train: tuple of np.ndarray (x_train, y_train)
-    :param args_dict: a dict of model arguments
-    :returns: samples_beanmachine(dict): posterior samples of all parameters
-    :returns: timing_info(dict): compile_time, inference_time
-    """
-    x_train, y_train = data_train
-    K, N = x_train.shape  # K = num features, N = num observations
-    assert y_train.shape == (N,)
-    assert model is None
-    num_samples = int(args_dict["num_samples"])
-    alpha_scale, beta_scale, beta_loc, sigma_mean = args_dict["model_args"]
-    # compile the model
-    compile_start = time.time()
-    g = bmgraph.Graph()
-    # nu ~ Gamma(shape = 2, rate = 0.1)
-    two = g.add_constant_pos_real(2.0)
-    pt_one = g.add_constant_pos_real(0.1)
-    nu_prior = g.add_distribution(
-        bmgraph.DistributionType.GAMMA, bmgraph.AtomicType.POS_REAL, [two, pt_one]
-    )
-    nu = g.add_operator(bmgraph.OperatorType.SAMPLE, [nu_prior])
-    # sigma ~ Exponential(sigma_mean) = Gamma(shape = 1, rate = 1/sigma_mean)
-    one = g.add_constant_pos_real(1.0)
-    inv_sigma_mean = g.add_constant_pos_real(float(1.0 / sigma_mean))
-    sigma_prior = g.add_distribution(
-        bmgraph.DistributionType.GAMMA,
-        bmgraph.AtomicType.POS_REAL,
-        [one, inv_sigma_mean],
-    )
-    sigma = g.add_operator(bmgraph.OperatorType.SAMPLE, [sigma_prior])
-    # alpha ~ Normal(0, alpha_scale)
-    zero = g.add_constant(0.0)
-    alpha_scale = g.add_constant_pos_real(float(alpha_scale))
-    alpha_prior = g.add_distribution(
-        bmgraph.DistributionType.NORMAL, bmgraph.AtomicType.REAL, [zero, alpha_scale]
-    )
-    alpha = g.add_operator(bmgraph.OperatorType.SAMPLE, [alpha_prior])
-    # beta_j ~ Normal(beta_loc, beta_scale) for j in range(K)
-    beta_scale = g.add_constant_pos_real(float(beta_scale))
-    beta_loc = g.add_constant(float(beta_loc))
-    beta_prior = g.add_distribution(
-        bmgraph.DistributionType.NORMAL, bmgraph.AtomicType.REAL, [beta_loc, beta_scale]
-    )
-    beta = [g.add_operator(bmgraph.OperatorType.SAMPLE, [beta_prior]) for _ in range(K)]
-    # mean_i = alpha + sum(x_j_i * beta_j for j in range(K))
-    for i in range(N):
-        sum_i = []
-        for j in range(K):
-            x_j_i = g.add_constant(float(x_train[j, i]))
-            x_j_i_times_beta_j = g.add_operator(
-                bmgraph.OperatorType.MULTIPLY, [x_j_i, beta[j]]
-            )
-            sum_i.append(x_j_i_times_beta_j)
-        sum_i.append(alpha)
-        mean_i = g.add_operator(bmgraph.OperatorType.ADD, sum_i)
-        # y_i ~ StudentT(nu, mean_i, sigma)
-        studentt_i = g.add_distribution(
-            bmgraph.DistributionType.STUDENT_T,
-            bmgraph.AtomicType.REAL,
-            [nu, mean_i, sigma],
+class RobustRegression(PPLBenchPPL):
+    def obtain_posterior(
+        self, data_train: Tuple[Any, Any], args_dict: Dict, model
+    ) -> Tuple[List, Dict]:
+        """
+        Beanmachine impmementation of logisitc regression model.
+
+        :param data_train: tuple of np.ndarray (x_train, y_train)
+        :param args_dict: a dict of model arguments
+        :returns: samples_beanmachine(dict): posterior samples of all parameters
+        :returns: timing_info(dict): compile_time, inference_time
+        """
+        x_train, y_train = data_train
+        K, N = x_train.shape  # K = num features, N = num observations
+        assert y_train.shape == (N,)
+        assert model is None
+        num_samples = int(args_dict["num_samples"])
+        alpha_scale, beta_scale, beta_loc, sigma_mean = args_dict["model_args"]
+        # compile the model
+        compile_start = time.time()
+        g = bmgraph.Graph()
+        # nu ~ Gamma(shape = 2, rate = 0.1)
+        two = g.add_constant_pos_real(2.0)
+        pt_one = g.add_constant_pos_real(0.1)
+        nu_prior = g.add_distribution(
+            bmgraph.DistributionType.GAMMA, bmgraph.AtomicType.POS_REAL, [two, pt_one]
         )
-        y_i = g.add_operator(bmgraph.OperatorType.SAMPLE, [studentt_i])
-        g.observe(y_i, float(y_train[i]))
-    # We want P (nu, sigma, alpha, beta_j for j in range(K)
-    #            | x_i, y_i  for i in range(N))
-    g.query(nu)
-    g.query(sigma)
-    g.query(alpha)
-    for j in range(K):
-        g.query(beta[j])
-    # we will include the inference time for one sample into the compile time
-    # and subtract this from inference time later
-    infer_setup_start = time.time()
-    g.infer(1, bmgraph.InferenceType.NMC)
-    infer_setup_time = time.time() - infer_setup_start
-    compile_time = time.time() - compile_start
-    infer_start = time.time()
-    samples = g.infer(
-        num_samples, bmgraph.InferenceType.NMC, int(time.time() * 1000) % 2 ** 31
-    )
-    infer_time = time.time() - infer_start - infer_setup_time
-    timing_info = {"compile_time": compile_time, "inference_time": infer_time}
-    print(f"bmgraph inference time {infer_time:.1f}")
-    sample_dicts = []
-    for sample in samples:
-        dict_ = {}
-        dict_["nu"] = sample[0]
-        dict_["sigma"] = sample[1]
-        dict_["alpha"] = sample[2]
-        dict_["beta"] = np.array(sample[3:])
-        sample_dicts.append(dict_)
-    return sample_dicts, timing_info
+        nu = g.add_operator(bmgraph.OperatorType.SAMPLE, [nu_prior])
+        # sigma ~ Exponential(sigma_mean) = Gamma(shape = 1, rate = 1/sigma_mean)
+        one = g.add_constant_pos_real(1.0)
+        inv_sigma_mean = g.add_constant_pos_real(float(1.0 / sigma_mean))
+        sigma_prior = g.add_distribution(
+            bmgraph.DistributionType.GAMMA,
+            bmgraph.AtomicType.POS_REAL,
+            [one, inv_sigma_mean],
+        )
+        sigma = g.add_operator(bmgraph.OperatorType.SAMPLE, [sigma_prior])
+        # alpha ~ Normal(0, alpha_scale)
+        zero = g.add_constant(0.0)
+        alpha_scale = g.add_constant_pos_real(float(alpha_scale))
+        alpha_prior = g.add_distribution(
+            bmgraph.DistributionType.NORMAL,
+            bmgraph.AtomicType.REAL,
+            [zero, alpha_scale],
+        )
+        alpha = g.add_operator(bmgraph.OperatorType.SAMPLE, [alpha_prior])
+        # beta_j ~ Normal(beta_loc, beta_scale) for j in range(K)
+        beta_scale = g.add_constant_pos_real(float(beta_scale))
+        beta_loc = g.add_constant(float(beta_loc))
+        beta_prior = g.add_distribution(
+            bmgraph.DistributionType.NORMAL,
+            bmgraph.AtomicType.REAL,
+            [beta_loc, beta_scale],
+        )
+        beta = [
+            g.add_operator(bmgraph.OperatorType.SAMPLE, [beta_prior]) for _ in range(K)
+        ]
+        # mean_i = alpha + sum(x_j_i * beta_j for j in range(K))
+        for i in range(N):
+            sum_i = []
+            for j in range(K):
+                x_j_i = g.add_constant(float(x_train[j, i]))
+                x_j_i_times_beta_j = g.add_operator(
+                    bmgraph.OperatorType.MULTIPLY, [x_j_i, beta[j]]
+                )
+                sum_i.append(x_j_i_times_beta_j)
+            sum_i.append(alpha)
+            mean_i = g.add_operator(bmgraph.OperatorType.ADD, sum_i)
+            # y_i ~ StudentT(nu, mean_i, sigma)
+            studentt_i = g.add_distribution(
+                bmgraph.DistributionType.STUDENT_T,
+                bmgraph.AtomicType.REAL,
+                [nu, mean_i, sigma],
+            )
+            y_i = g.add_operator(bmgraph.OperatorType.SAMPLE, [studentt_i])
+            g.observe(y_i, float(y_train[i]))
+        # We want P (nu, sigma, alpha, beta_j for j in range(K)
+        #            | x_i, y_i  for i in range(N))
+        g.query(nu)
+        g.query(sigma)
+        g.query(alpha)
+        for j in range(K):
+            g.query(beta[j])
+        # we will include the inference time for one sample into the compile time
+        # and subtract this from inference time later
+        infer_setup_start = time.time()
+        g.infer(1, bmgraph.InferenceType.NMC)
+        infer_setup_time = time.time() - infer_setup_start
+        compile_time = time.time() - compile_start
+        infer_start = time.time()
+        samples = g.infer(
+            num_samples, bmgraph.InferenceType.NMC, int(time.time() * 1000) % 2 ** 31
+        )
+        infer_time = time.time() - infer_start - infer_setup_time
+        timing_info = {"compile_time": compile_time, "inference_time": infer_time}
+        print(f"bmgraph inference time {infer_time:.1f}")
+        sample_dicts = []
+        for sample in samples:
+            dict_ = {}
+            dict_["nu"] = sample[0]
+            dict_["sigma"] = sample[1]
+            dict_["alpha"] = sample[2]
+            dict_["beta"] = np.array(sample[3:])
+            sample_dicts.append(dict_)
+        return sample_dicts, timing_info

--- a/ppls/bootstrapping/logistic_regression.py
+++ b/ppls/bootstrapping/logistic_regression.py
@@ -2,7 +2,9 @@
 import time
 from random import choices
 
-from sklearn.linear_model import LogisticRegression
+from sklearn.linear_model import LogisticRegression as LR
+
+from ..pplbench_ppl import PPLBenchPPL
 
 
 """
@@ -10,45 +12,46 @@ For model definition, see models/logisticRegressionModel.py
 """
 
 
-def obtain_posterior(data_train, args_dict, model):
-    """
-    Bootstrap impmementation of logistic regression model.
+class LogisticRegression(PPLBenchPPL):
+    def obtain_posterior(self, data_train, args_dict, model=None):
+        """
+        Bootstrap impmementation of logistic regression model.
 
-    :param data_train: tuple of np.ndarray (x_train, y_train)
-    :param args_dict: a dict of model arguments
-    :returns: samples_bootstrap(dict): posterior samples of all parameters
-    :returns: timing_info(dict): compile_time, inference_time
-    """
+        :param data_train: tuple of np.ndarray (x_train, y_train)
+        :param args_dict: a dict of model arguments
+        :returns: samples_bootstrap(dict): posterior samples of all parameters
+        :returns: timing_info(dict): compile_time, inference_time
+        """
 
-    # shape of x_train: (num_features, num_samples)
-    x_train, y_train = data_train
-    N = int(x_train.shape[1])
-    num_samples = args_dict["num_samples_bootstrapping"]
+        # shape of x_train: (num_features, num_samples)
+        x_train, y_train = data_train
+        N = int(x_train.shape[1])
+        num_samples = args_dict["num_samples_bootstrapping"]
 
-    # x_train is now (num_samples, num_features)
-    x_train = x_train.T
+        # x_train is now (num_samples, num_features)
+        x_train = x_train.T
 
-    samples = []
-    inference_start_time = time.time()
-    for i in range(num_samples):
-        sample_dict = {}
-        # randomnly pick with replacement N training observations
-        indices = [i for i in range(N)]
-        chosen_indices = choices(indices, k=N)
-        x_train_sampled = x_train[chosen_indices, :]
-        y_train_sampled = y_train[chosen_indices]
+        samples = []
+        inference_start_time = time.time()
+        for _i in range(num_samples):
+            sample_dict = {}
+            # randomnly pick with replacement N training observations
+            indices = list(range(N))
+            chosen_indices = choices(indices, k=N)
+            x_train_sampled = x_train[chosen_indices, :]
+            y_train_sampled = y_train[chosen_indices]
 
-        clf = LogisticRegression(random_state=0).fit(x_train_sampled, y_train_sampled)
+            clf = LR(random_state=0).fit(x_train_sampled, y_train_sampled)
 
-        alpha = clf.intercept_
+            alpha = clf.intercept_
 
-        # shape: (1, num_features)
-        beta = clf.coef_
-        sample_dict["alpha"] = alpha
-        sample_dict["beta"] = beta
-        samples.append(sample_dict)
+            # shape: (1, num_features)
+            beta = clf.coef_
+            sample_dict["alpha"] = alpha
+            sample_dict["beta"] = beta
+            samples.append(sample_dict)
 
-    inference_time = time.time() - inference_start_time
+        inference_time = time.time() - inference_start_time
 
-    timing_info = {"compile_time": 0, "inference_time": inference_time}
-    return (samples, timing_info)
+        timing_info = {"compile_time": 0, "inference_time": inference_time}
+        return (samples, timing_info)

--- a/ppls/jags/crowd_sourced_annotation.py
+++ b/ppls/jags/crowd_sourced_annotation.py
@@ -8,6 +8,8 @@ import numpy as np
 # pyre-fixme[21]: Could not find `pyjags`.
 import pyjags
 
+from ..pplbench_ppl import PPLBenchPPL
+
 
 CODE = """
 data {
@@ -45,73 +47,75 @@ model {
 """
 
 
-def obtain_posterior(data_train, args_dict, model=None):
-    """
-    Jags impmementation of robust regression model.
+class CrowdSourcedAnnotation(PPLBenchPPL):
+    def obtain_posterior(self, data_train, args_dict, model=None):
+        """
+        Jags impmementation of robust regression model.
 
-    Inputs:
-    - data_train(tuple of np.ndarray): vector_y, vector_J_i, num_labels
-    - args_dict: a dict of model arguments
-    Returns:
-    - samples_jags(dict): posterior samples of all parameters
-    - timing_info(dict): compile_time, inference_time
-    """
-    global CODE
-    vector_y, vector_J_i, num_labels = data_train
-    J = int(args_dict["k"])
-    n_items = len(num_labels)
-    K, _, expected_correctness, concentration = args_dict["model_args"]
-    # item array for jags; change from list-of-lengths format of num_labels
-    # to list-of-items associated with each label and labeler in vector_y, vector_J_i
-    item = []
-    for i in range(len(num_labels)):
-        item.extend(np.repeat(i + 1, num_labels[i]))
-    data_jags = {
-        "n_obs": len(vector_y),
-        "n_items": n_items,
-        "n_labelers": J,
-        "n_categories": K,
-        "expected_correctness": expected_correctness,
-        "concentration": concentration,
-        "labels": [i + 1 for i in vector_y],  # 0-indexed to 1-indexed
-        "labeler": [i + 1 for i in vector_J_i],  # 0-indexed to 1-indexed
-        "item": item,
-    }
+        Inputs:
+        - data_train(tuple of np.ndarray): vector_y, vector_J_i, num_labels
+        - args_dict: a dict of model arguments
+        Returns:
+        - samples_jags(dict): posterior samples of all parameters
+        - timing_info(dict): compile_time, inference_time
+        """
+        global CODE
+        vector_y, vector_J_i, num_labels = data_train
+        J = int(args_dict["k"])
+        n_items = len(num_labels)
+        K, _, expected_correctness, concentration = args_dict["model_args"]
+        # item array for jags; change from list-of-lengths format
+        # of num_labels to list-of-items associated with each label
+        # and labeler in vector_y, vector_J_i
+        item = []
+        for i in range(len(num_labels)):
+            item.extend(np.repeat(i + 1, num_labels[i]))
+        data_jags = {
+            "n_obs": len(vector_y),
+            "n_items": n_items,
+            "n_labelers": J,
+            "n_categories": K,
+            "expected_correctness": expected_correctness,
+            "concentration": concentration,
+            "labels": [i + 1 for i in vector_y],  # 0-indexed to 1-indexed
+            "labeler": [i + 1 for i in vector_J_i],  # 0-indexed to 1-indexed
+            "item": item,
+        }
 
-    # compile the model, time it
-    start_time = time.time()
-    brmodel = pyjags.Model(CODE, data=data_jags, chains=1, adapt=0)
-    elapsed_time_compile_jags = time.time() - start_time
-
-    if args_dict["inference_type"] == "mcmc":
-        # sample the parameter posteriors, time it
+        # compile the model, time it
         start_time = time.time()
-        # Choose the parameters to watch and iterations:
-        samples_jags = brmodel.sample(
-            int(args_dict["num_samples_jags"]), vars=["theta", "pi"]
-        )
-        elapsed_time_sample_jags = time.time() - start_time
-    elif args_dict["inference_type"] == "vi":
-        print("Jags does not support Variational Inference")
-        exit(1)
-    # repackage samples into shape required by PPLBench
-    samples = []
-    # move axes to facilitate iterating over samples
-    # change (sample, chain, values) to (chain, sample, value)
-    samples_jags["pi"] = np.moveaxis(samples_jags["pi"], [0, 1, 2], [2, 1, 0])
-    # change from (J, K, K, samples, chains) to (chains, samples, J, K, K)
-    samples_jags["theta"] = np.moveaxis(samples_jags["theta"], [3, 4], [1, 0])
-    for parameter in samples_jags.keys():
-        if samples_jags[parameter].shape[0] == 1:
-            samples_jags[parameter] = samples_jags[parameter].squeeze()
-    for i in range(int(args_dict["num_samples_jags"])):
-        sample_dict = {}
-        for parameter in samples_jags.keys():
-            sample_dict[parameter] = samples_jags[parameter][i]
-        samples.append(sample_dict)
-    timing_info = {
-        "compile_time": elapsed_time_compile_jags,
-        "inference_time": elapsed_time_sample_jags,
-    }
+        brmodel = pyjags.Model(CODE, data=data_jags, chains=1, adapt=0)
+        elapsed_time_compile_jags = time.time() - start_time
 
-    return (samples, timing_info)
+        if args_dict["inference_type"] == "mcmc":
+            # sample the parameter posteriors, time it
+            start_time = time.time()
+            # Choose the parameters to watch and iterations:
+            samples_jags = brmodel.sample(
+                int(args_dict["num_samples_jags"]), vars=["theta", "pi"]
+            )
+            elapsed_time_sample_jags = time.time() - start_time
+        elif args_dict["inference_type"] == "vi":
+            print("Jags does not support Variational Inference")
+            exit(1)
+        # repackage samples into shape required by PPLBench
+        samples = []
+        # move axes to facilitate iterating over samples
+        # change (sample, chain, values) to (chain, sample, value)
+        samples_jags["pi"] = np.moveaxis(samples_jags["pi"], [0, 1, 2], [2, 1, 0])
+        # change from (J, K, K, samples, chains) to (chains, samples, J, K, K)
+        samples_jags["theta"] = np.moveaxis(samples_jags["theta"], [3, 4], [1, 0])
+        for parameter in samples_jags.keys():
+            if samples_jags[parameter].shape[0] == 1:
+                samples_jags[parameter] = samples_jags[parameter].squeeze()
+        for i in range(int(args_dict["num_samples_jags"])):
+            sample_dict = {}
+            for parameter in samples_jags.keys():
+                sample_dict[parameter] = samples_jags[parameter][i]
+            samples.append(sample_dict)
+        timing_info = {
+            "compile_time": elapsed_time_compile_jags,
+            "inference_time": elapsed_time_sample_jags,
+        }
+
+        return (samples, timing_info)

--- a/ppls/jags/logistic_regression.py
+++ b/ppls/jags/logistic_regression.py
@@ -8,6 +8,8 @@ import numpy as np
 # pyre-fixme[21]: Could not find `pyjags`.
 import pyjags
 
+from ..pplbench_ppl import PPLBenchPPL
+
 
 CODE = """
 # Classification model
@@ -26,66 +28,67 @@ model {
 """
 
 
-def obtain_posterior(data_train, args_dict, model=None):
-    """
-    Jags impmementation of logistic regression model.
+class LogisticRegression(PPLBenchPPL):
+    def obtain_posterior(self, data_train, args_dict, model=None):
+        """
+        Jags impmementation of logistic regression model.
 
-    Inputs:
-    - data_train(tuple of np.ndarray): x_train, y_train
-    - args_dict: a dict of model arguments
-    Returns:
-    - samples_jags(dict): posterior samples of all parameters
-    - timing_info(dict): compile_time, inference_time
-    """
-    global CODE
-    x_train, y_train = data_train
-    N = int(x_train.shape[1])
-    K = int(x_train.shape[0])
-    alpha_scale = (args_dict["model_args"])[0]
-    beta_scale = (args_dict["model_args"])[1]
+        Inputs:
+        - data_train(tuple of np.ndarray): x_train, y_train
+        - args_dict: a dict of model arguments
+        Returns:
+        - samples_jags(dict): posterior samples of all parameters
+        - timing_info(dict): compile_time, inference_time
+        """
+        global CODE
+        x_train, y_train = data_train
+        N = int(x_train.shape[1])
+        K = int(x_train.shape[0])
+        alpha_scale = (args_dict["model_args"])[0]
+        beta_scale = (args_dict["model_args"])[1]
 
-    data_jags = {
-        "N": N,
-        "K": K,
-        "X": x_train,
-        "y": y_train,
-        "scale_alpha": alpha_scale,
-        "scale_beta": beta_scale * np.ones(K),
-    }
+        data_jags = {
+            "N": N,
+            "K": K,
+            "X": x_train,
+            "y": y_train,
+            "scale_alpha": alpha_scale,
+            "scale_beta": beta_scale * np.ones(K),
+        }
 
-    # compile the model, time it
-    start_time = time.time()
-    brmodel = pyjags.Model(CODE, data=data_jags, chains=1, adapt=0)
-    elapsed_time_compile_jags = time.time() - start_time
-
-    if args_dict["inference_type"] == "mcmc":
-        # sample the parameter posteriors, time it
+        # compile the model, time it
         start_time = time.time()
-        # Choose the parameters to watch and iterations:
-        samples_jags = brmodel.sample(
-            int(args_dict["num_samples_jags"]), vars=["alpha", "beta"]
-        )
-        elapsed_time_sample_jags = time.time() - start_time
-    elif args_dict["inference_type"] == "vi":
-        print("Jags does not support Variational Inference")
-        exit()
+        brmodel = pyjags.Model(CODE, data=data_jags, chains=1, adapt=0)
+        elapsed_time_compile_jags = time.time() - start_time
 
-    # repackage samples into shape required by PPLBench
-    samples = []
-    # move axes to facilitate iterating over samples
-    # change (sample, chain, values) to (chain, sample, value)
-    samples_jags["beta"] = np.moveaxis(samples_jags["beta"], [0, 1, 2], [1, 0, 2])
-    for parameter in samples_jags.keys():
-        if samples_jags[parameter].shape[0] == 1:
-            samples_jags[parameter] = samples_jags[parameter].squeeze()
-    for i in range(int(args_dict["num_samples_jags"])):
-        sample_dict = {}
+        if args_dict["inference_type"] == "mcmc":
+            # sample the parameter posteriors, time it
+            start_time = time.time()
+            # Choose the parameters to watch and iterations:
+            samples_jags = brmodel.sample(
+                int(args_dict["num_samples_jags"]), vars=["alpha", "beta"]
+            )
+            elapsed_time_sample_jags = time.time() - start_time
+        elif args_dict["inference_type"] == "vi":
+            print("Jags does not support Variational Inference")
+            exit()
+
+        # repackage samples into shape required by PPLBench
+        samples = []
+        # move axes to facilitate iterating over samples
+        # change (sample, chain, values) to (chain, sample, value)
+        samples_jags["beta"] = np.moveaxis(samples_jags["beta"], [0, 1, 2], [1, 0, 2])
         for parameter in samples_jags.keys():
-            sample_dict[parameter] = samples_jags[parameter][i].T
-        samples.append(sample_dict)
-    timing_info = {
-        "compile_time": elapsed_time_compile_jags,
-        "inference_time": elapsed_time_sample_jags,
-    }
+            if samples_jags[parameter].shape[0] == 1:
+                samples_jags[parameter] = samples_jags[parameter].squeeze()
+        for i in range(int(args_dict["num_samples_jags"])):
+            sample_dict = {}
+            for parameter in samples_jags.keys():
+                sample_dict[parameter] = samples_jags[parameter][i].T
+            samples.append(sample_dict)
+        timing_info = {
+            "compile_time": elapsed_time_compile_jags,
+            "inference_time": elapsed_time_sample_jags,
+        }
 
-    return (samples, timing_info)
+        return (samples, timing_info)

--- a/ppls/jags/noisy_or_topic.py
+++ b/ppls/jags/noisy_or_topic.py
@@ -8,71 +8,76 @@ import numpy as np
 # pyre-fixme[21]: Could not find `pyjags`.
 import pyjags
 
+from ..pplbench_ppl import PPLBenchPPL
 
-def obtain_posterior(data_train, args_dict, model):
-    """
-    Jags impmementation of Noisy-Or Topic Model.
 
-    Inputs:
-    - data_train(tuple of np.ndarray): graph, words
-    - args_dict: a dict of model arguments
-    Returns:
-    - samples_jags(dict): posterior samples of all parameters
-    - timing_info(dict): compile_time, inference_time
-    """
-    graph = model
-    words = data_train
-    K = int(args_dict["k"])
-    word_fraction = (args_dict["model_args"])[3]
-    T = int(K * (1 - word_fraction))
-    assert len(words.shape) == 1
-    nodearray = np.concatenate([np.zeros(T), words])
-    mask = np.concatenate((np.ones(T), np.zeros_like(words)))
-    # Construct the jags code for the graph
-    code = "model {\n"
-    for node in range(K):
-        if node == 0:
-            code += "    node[{}] <- 1\n".format(node + 1)
-        else:
-            code += "    prob[{}] <- 1 - exp(-(".format(node + 1)
-            for par, wt in enumerate(graph[:, node]):
-                if wt:
-                    code += "node[{}]*{} + ".format(par + 1, wt)
-            code += "0))\n"
-            code += "    node[{}] ~ dbern(prob[{}])\n".format(node + 1, node + 1)
-    code += "}"
-    data_jags = {"node": np.ma.masked_array(data=nodearray, mask=mask)}
-    # compile the model, time it
-    start_time = time.time()
-    model = pyjags.Model(code, data=data_jags, chains=1, adapt=0)
-    elapsed_time_compile_jags = time.time() - start_time
-    if args_dict["inference_type"] == "mcmc":
-        # sample the parameter posteriors, time it
+class NoisyOrTopic(PPLBenchPPL):
+    def obtain_posterior(self, data_train, args_dict, model):
+        """
+        Jags impmementation of Noisy-Or Topic Model.
+
+        Inputs:
+        - data_train(tuple of np.ndarray): graph, words
+        - args_dict: a dict of model arguments
+        Returns:
+        - samples_jags(dict): posterior samples of all parameters
+        - timing_info(dict): compile_time, inference_time
+        """
+        graph = model
+        words = data_train
+        K = int(args_dict["k"])
+        word_fraction = (args_dict["model_args"])[3]
+        T = int(K * (1 - word_fraction))
+        assert len(words.shape) == 1
+        nodearray = np.concatenate([np.zeros(T), words])
+        mask = np.concatenate((np.ones(T), np.zeros_like(words)))
+        # Construct the jags code for the graph
+        code = "model {\n"
+        for node in range(K):
+            if node == 0:
+                code += "    node[{}] <- 1\n".format(node + 1)
+            else:
+                code += "    prob[{}] <- 1 - exp(-(".format(node + 1)
+                for par, wt in enumerate(graph[:, node]):
+                    if wt:
+                        code += "node[{}]*{} + ".format(par + 1, wt)
+                code += "0))\n"
+                code += "    node[{}] ~ dbern(prob[{}])\n".format(node + 1, node + 1)
+        code += "}"
+        data_jags = {"node": np.ma.masked_array(data=nodearray, mask=mask)}
+        # compile the model, time it
         start_time = time.time()
-        samples_jags = model.sample(int(args_dict["num_samples_jags"]), vars=["node"])
-        elapsed_time_sample_jags = time.time() - start_time
-    elif args_dict["inference_type"] == "vi":
-        print("Jags does not support Variational Inference")
-        exit()
-    # repackage samples into shape required by PPLBench
-    samples = []
-    # move axes to facilitate iterating over samples
-    # change (sample, chain, values) to (chain, sample, value)
-    samples_jags["node"] = np.moveaxis(samples_jags["node"], [0, 1, 2], [1, 0, 2])
-    for parameter in samples_jags.keys():
-        # samples ndarray may have an extra dimension for num_chains which is 1
-        # in PPLbench, we flatten it
-        if samples_jags[parameter].shape[0] == 1:
-            samples_jags[parameter] = samples_jags[parameter].squeeze()
-    for i in range(int(args_dict["num_samples_jags"])):
-        sample_dict = {}
+        model = pyjags.Model(code, data=data_jags, chains=1, adapt=0)
+        elapsed_time_compile_jags = time.time() - start_time
+        if args_dict["inference_type"] == "mcmc":
+            # sample the parameter posteriors, time it
+            start_time = time.time()
+            samples_jags = model.sample(
+                int(args_dict["num_samples_jags"]), vars=["node"]
+            )
+            elapsed_time_sample_jags = time.time() - start_time
+        elif args_dict["inference_type"] == "vi":
+            print("Jags does not support Variational Inference")
+            exit()
+        # repackage samples into shape required by PPLBench
+        samples = []
+        # move axes to facilitate iterating over samples
+        # change (sample, chain, values) to (chain, sample, value)
+        samples_jags["node"] = np.moveaxis(samples_jags["node"], [0, 1, 2], [1, 0, 2])
         for parameter in samples_jags.keys():
-            # convert from [parameter][sample] dict to [sample][parameter]
-            # keep only the topics
-            sample_dict[parameter] = samples_jags[parameter][i].reshape(-1)[:T]
-        samples.append(sample_dict)
-    timing_info = {
-        "compile_time": elapsed_time_compile_jags,
-        "inference_time": elapsed_time_sample_jags,
-    }
-    return (samples, timing_info)
+            # samples ndarray may have an extra dimension for num_chains which is 1
+            # in PPLbench, we flatten it
+            if samples_jags[parameter].shape[0] == 1:
+                samples_jags[parameter] = samples_jags[parameter].squeeze()
+        for i in range(int(args_dict["num_samples_jags"])):
+            sample_dict = {}
+            for parameter in samples_jags.keys():
+                # convert from [parameter][sample] dict to [sample][parameter]
+                # keep only the topics
+                sample_dict[parameter] = samples_jags[parameter][i].reshape(-1)[:T]
+            samples.append(sample_dict)
+        timing_info = {
+            "compile_time": elapsed_time_compile_jags,
+            "inference_time": elapsed_time_sample_jags,
+        }
+        return (samples, timing_info)

--- a/ppls/jags/robust_regression.py
+++ b/ppls/jags/robust_regression.py
@@ -8,6 +8,8 @@ import numpy as np
 # pyre-fixme[21]: Could not find `pyjags`.
 import pyjags
 
+from ..pplbench_ppl import PPLBenchPPL
+
 
 CODE = """
 # Linear Model with Student-t Errors
@@ -27,67 +29,69 @@ model {
 """
 
 
-def obtain_posterior(data_train, args_dict, model=None):
-    """
-    Jags impmementation of robust regression model.
+class RobustRegression(PPLBenchPPL):
+    def obtain_posterior(self, data_train, args_dict, model=None):
+        """
+        Jags impmementation of robust regression model.
 
-    Inputs:
-    - data_train(tuple of np.ndarray): x_train, y_train
-    - args_dict: a dict of model arguments
-    Returns:
-    - samples_jags(dict): posterior samples of all parameters
-    - timing_info(dict): compile_time, inference_time
-    """
-    global CODE
-    x_train, y_train = data_train
-    N = int(x_train.shape[1])
-    K = int(x_train.shape[0])
-    alpha_scale, beta_scale, beta_loc, sigma_mean = args_dict["model_args"]
+        Inputs:
+        - data_train(tuple of np.ndarray): x_train, y_train
+        - args_dict: a dict of model arguments
+        Returns:
+        - samples_jags(dict): posterior samples of all parameters
+        - timing_info(dict): compile_time, inference_time
+        """
+        global CODE
+        x_train, y_train = data_train
+        N = int(x_train.shape[1])
+        K = int(x_train.shape[0])
+        alpha_scale, beta_scale, beta_loc, sigma_mean = args_dict["model_args"]
 
-    data_jags = {
-        "N": N,
-        "K": K,
-        "X": x_train,
-        "y": y_train,
-        "scale_alpha": alpha_scale,
-        "scale_beta": beta_scale,
-        "loc_beta": beta_loc,
-        "rate_sigma": 1.0 / sigma_mean,
-    }
+        data_jags = {
+            "N": N,
+            "K": K,
+            "X": x_train,
+            "y": y_train,
+            "scale_alpha": alpha_scale,
+            "scale_beta": beta_scale,
+            "loc_beta": beta_loc,
+            "rate_sigma": 1.0 / sigma_mean,
+        }
 
-    # compile the model, time it
-    start_time = time.time()
-    brmodel = pyjags.Model(CODE, data=data_jags, chains=1, adapt=0)
-    elapsed_time_compile_jags = time.time() - start_time
-
-    if args_dict["inference_type"] == "mcmc":
-        # sample the parameter posteriors, time it
+        # compile the model, time it
         start_time = time.time()
-        # Choose the parameters to watch and iterations:
-        samples_jags = brmodel.sample(
-            int(args_dict["num_samples_jags"]), vars=["nu", "alpha", "beta", "sigma"]
-        )
-        elapsed_time_sample_jags = time.time() - start_time
-    elif args_dict["inference_type"] == "vi":
-        print("Jags does not support Variational Inference")
-        exit()
+        brmodel = pyjags.Model(CODE, data=data_jags, chains=1, adapt=0)
+        elapsed_time_compile_jags = time.time() - start_time
 
-    # repackage samples into shape required by PPLBench
-    samples = []
-    # move axes to facilitate iterating over samples
-    # change (sample, chain, values) to (chain, sample, value)
-    samples_jags["beta"] = np.moveaxis(samples_jags["beta"], [0, 1, 2], [1, 0, 2])
-    for parameter in samples_jags.keys():
-        if samples_jags[parameter].shape[0] == 1:
-            samples_jags[parameter] = samples_jags[parameter].squeeze()
-    for i in range(int(args_dict["num_samples_jags"])):
-        sample_dict = {}
+        if args_dict["inference_type"] == "mcmc":
+            # sample the parameter posteriors, time it
+            start_time = time.time()
+            # Choose the parameters to watch and iterations:
+            samples_jags = brmodel.sample(
+                int(args_dict["num_samples_jags"]),
+                vars=["nu", "alpha", "beta", "sigma"],
+            )
+            elapsed_time_sample_jags = time.time() - start_time
+        elif args_dict["inference_type"] == "vi":
+            print("Jags does not support Variational Inference")
+            exit()
+
+        # repackage samples into shape required by PPLBench
+        samples = []
+        # move axes to facilitate iterating over samples
+        # change (sample, chain, values) to (chain, sample, value)
+        samples_jags["beta"] = np.moveaxis(samples_jags["beta"], [0, 1, 2], [1, 0, 2])
         for parameter in samples_jags.keys():
-            sample_dict[parameter] = samples_jags[parameter][i].T
-        samples.append(sample_dict)
-    timing_info = {
-        "compile_time": elapsed_time_compile_jags,
-        "inference_time": elapsed_time_sample_jags,
-    }
+            if samples_jags[parameter].shape[0] == 1:
+                samples_jags[parameter] = samples_jags[parameter].squeeze()
+        for i in range(int(args_dict["num_samples_jags"])):
+            sample_dict = {}
+            for parameter in samples_jags.keys():
+                sample_dict[parameter] = samples_jags[parameter][i].T
+            samples.append(sample_dict)
+        timing_info = {
+            "compile_time": elapsed_time_compile_jags,
+            "inference_time": elapsed_time_sample_jags,
+        }
 
-    return (samples, timing_info)
+        return (samples, timing_info)

--- a/ppls/nmc/crowd_sourced_annotation.py
+++ b/ppls/nmc/crowd_sourced_annotation.py
@@ -6,6 +6,7 @@ from torch import tensor
 from torch.distributions import Categorical, Dirichlet
 from tqdm import tqdm
 
+from ..pplbench_ppl import PPLBenchPPL
 from .utils import gradients, simplex_proposer
 
 
@@ -148,7 +149,7 @@ class State:
             * true_one_hot,
         )
         ssum = score.sum()
-        grad, = torch.autograd.grad(
+        (grad,) = torch.autograd.grad(
             ssum, confusion, retain_graph=True, create_graph=True
         )
         # simulate the cost of computing a vector Hessian
@@ -169,43 +170,44 @@ class State:
         return score, simplex_proposer(prevalence, grad, hess)
 
 
-def obtain_posterior(data_train, args_dict, model=None):
-    """
-    NMC implementation of crowdsourced annotation model
+class CrowdSourcedAnnotation(PPLBenchPPL):
+    def obtain_posterior(self, data_train, args_dict, model=None):
+        """
+        NMC implementation of crowdsourced annotation model
 
-    Inputs:
-    - data_train(tuple of np.ndarray): vector_y, vector_J_i, num_labels
-    - args_dict: a dict of model arguments
-    Returns:
-    - samples(dict): posterior samples of all parameters
-    - timing_info(dict): compile_time, inference_time
-    """
-    num_samples = args_dict["num_samples_nmc"]
-    n_categories, _, expected_correctness, concentration = args_dict["model_args"]
-    # first parse out the data into static fields in the State class
-    compile_time_t1 = time.time()
-    State.init_class(
-        int(args_dict["k"]),
-        n_categories,
-        expected_correctness,
-        concentration,
-        *data_train
-    )
-    curr = State()
-    compile_time_t2 = time.time()
-    # repeatedly update the state
-    infer_time_t1 = time.time()
-    samples = []
-    for _i in tqdm(range(num_samples), desc="inference", leave=False):
-        curr.update_()
-        samples_dict = {
-            "theta": curr.confusion.clone().numpy(),
-            "pi": curr.prevalence.clone().numpy(),
+        Inputs:
+        - data_train(tuple of np.ndarray): vector_y, vector_J_i, num_labels
+        - args_dict: a dict of model arguments
+        Returns:
+        - samples(dict): posterior samples of all parameters
+        - timing_info(dict): compile_time, inference_time
+        """
+        num_samples = args_dict["num_samples_nmc"]
+        n_categories, _, expected_correctness, concentration = args_dict["model_args"]
+        # first parse out the data into static fields in the State class
+        compile_time_t1 = time.time()
+        State.init_class(
+            int(args_dict["k"]),
+            n_categories,
+            expected_correctness,
+            concentration,
+            *data_train
+        )
+        curr = State()
+        compile_time_t2 = time.time()
+        # repeatedly update the state
+        infer_time_t1 = time.time()
+        samples = []
+        for _i in tqdm(range(num_samples), desc="inference", leave=False):
+            curr.update_()
+            samples_dict = {
+                "theta": curr.confusion.clone().numpy(),
+                "pi": curr.prevalence.clone().numpy(),
+            }
+            samples.append(samples_dict)
+        infer_time_t2 = time.time()
+        timing_info = {
+            "compile_time": compile_time_t2 - compile_time_t1,
+            "inference_time": infer_time_t2 - infer_time_t1,
         }
-        samples.append(samples_dict)
-    infer_time_t2 = time.time()
-    timing_info = {
-        "compile_time": compile_time_t2 - compile_time_t1,
-        "inference_time": infer_time_t2 - infer_time_t1,
-    }
-    return (samples, timing_info)
+        return (samples, timing_info)

--- a/ppls/nmc/logistic_regression.py
+++ b/ppls/nmc/logistic_regression.py
@@ -8,83 +8,85 @@ from torch import tensor
 from torch.distributions import Bernoulli, Normal
 from tqdm import tqdm
 
+from ..pplbench_ppl import PPLBenchPPL
 from .utils import gradients, real_proposer
 
 
-def obtain_posterior(
-    data_train: Tuple[Any, Any], args_dict: Dict, model=None
-) -> Tuple[List, Dict]:
-    """
-    Beanmachine impmementation of logisitc regression model.
+class LogisticRegression(PPLBenchPPL):
+    def obtain_posterior(
+        self, data_train: Tuple[Any, Any], args_dict: Dict, model=None
+    ) -> Tuple[List, Dict]:
+        """
+        Beanmachine impmementation of logisitc regression model.
 
-    :param data_train: tuple of np.ndarray (x_train, y_train)
-    :param args_dict: a dict of model arguments
-    :returns: samples_beanmachine(dict): posterior samples of all parameters
-    :returns: timing_info(dict): compile_time, inference_time
-    """
-    # shape of x_train: (num_features, num_samples)
-    x_train, y_train = data_train
-    y_train = np.array(y_train, dtype=np.float32)
-    x_train = np.array(x_train, dtype=np.float32)
-    x_train = tensor(x_train)
-    y_train = tensor([tensor(y) for y in y_train])
-    N = int(x_train.shape[1])
-    K = int(x_train.shape[0])
-    assert y_train.shape == (N,)
+        :param data_train: tuple of np.ndarray (x_train, y_train)
+        :param args_dict: a dict of model arguments
+        :returns: samples_beanmachine(dict): posterior samples of all parameters
+        :returns: timing_info(dict): compile_time, inference_time
+        """
+        # shape of x_train: (num_features, num_samples)
+        x_train, y_train = data_train
+        y_train = np.array(y_train, dtype=np.float32)
+        x_train = np.array(x_train, dtype=np.float32)
+        x_train = tensor(x_train)
+        y_train = tensor([tensor(y) for y in y_train])
+        N = int(x_train.shape[1])
+        K = int(x_train.shape[0])
+        assert y_train.shape == (N,)
 
-    alpha_scale = float((args_dict["model_args"])[0])
-    beta_scale = float((args_dict["model_args"])[1])
-    beta_loc = float((args_dict["model_args"])[2])
-    num_samples = args_dict["num_samples_nmc"]
+        alpha_scale = float((args_dict["model_args"])[0])
+        beta_scale = float((args_dict["model_args"])[1])
+        beta_loc = float((args_dict["model_args"])[2])
+        num_samples = args_dict["num_samples_nmc"]
 
-    # x_train has shape (K+1) x N
-    x_train = torch.cat((torch.ones((1, N)), x_train))
-    # we construct the prior to have mean and std with shape (K+1)
-    prior = Normal(
-        tensor([0.0] + ([beta_loc] * K)), tensor([alpha_scale] + ([beta_scale] * K))
-    )
-
-    def log_joint(theta):
-        score = prior.log_prob(theta).sum()
-        mu = torch.mm(theta.unsqueeze(dim=0), x_train).squeeze(dim=0)
-        score += Bernoulli(logits=mu).log_prob(y_train).sum()
-        return score
-
-    def get_score_and_proposer(theta):
-        theta.requires_grad_(True)
-        score = log_joint(theta)
-        grad, hess = gradients(score, theta)
-        grad = grad.detach()
-        hess = hess.detach()
-        theta.requires_grad_(False)
-        proposer = real_proposer(theta, grad, hess)
-        return score, proposer
-
-    # initialize to zero
-    samples = []
-    theta = torch.zeros(K + 1, requires_grad=True)
-    score, proposer = get_score_and_proposer(theta)
-    t1 = time.time()
-    for _i in tqdm(range(num_samples), desc="inference", leave=False):
-        theta2 = proposer.sample()
-        score2, proposer2 = get_score_and_proposer(theta2)
-        logacc = (
-            score2
-            - score
-            + proposer2.log_prob(theta).sum()
-            - proposer.log_prob(theta2).sum()
+        # x_train has shape (K+1) x N
+        x_train = torch.cat((torch.ones((1, N)), x_train))
+        # we construct the prior to have mean and std with shape (K+1)
+        prior = Normal(
+            tensor([0.0] + ([beta_loc] * K)), tensor([alpha_scale] + ([beta_scale] * K))
         )
-        if logacc > 0 or Bernoulli(probs=torch.exp(logacc)).sample().item():
-            theta, score, proposer = theta2, score2, proposer2
-        samples.append(theta.clone())
-    t2 = time.time()
-    samples_formatted = []
-    for i in tqdm(range(num_samples), desc="collect", leave=False):
-        sample_dict = {
-            "alpha": samples[i][0].item(),
-            "beta": samples[i][1:].detach().numpy(),
-        }
-        samples_formatted.append(sample_dict)
 
-    timing_info = {"compile_time": 0, "inference_time": t2 - t1}
-    return (samples_formatted, timing_info)
+        def log_joint(theta):
+            score = prior.log_prob(theta).sum()
+            mu = torch.mm(theta.unsqueeze(dim=0), x_train).squeeze(dim=0)
+            score += Bernoulli(logits=mu).log_prob(y_train).sum()
+            return score
+
+        def get_score_and_proposer(theta):
+            theta.requires_grad_(True)
+            score = log_joint(theta)
+            grad, hess = gradients(score, theta)
+            grad = grad.detach()
+            hess = hess.detach()
+            theta.requires_grad_(False)
+            proposer = real_proposer(theta, grad, hess)
+            return score, proposer
+
+        # initialize to zero
+        samples = []
+        theta = torch.zeros(K + 1, requires_grad=True)
+        score, proposer = get_score_and_proposer(theta)
+        t1 = time.time()
+        for _i in tqdm(range(num_samples), desc="inference", leave=False):
+            theta2 = proposer.sample()
+            score2, proposer2 = get_score_and_proposer(theta2)
+            logacc = (
+                score2
+                - score
+                + proposer2.log_prob(theta).sum()
+                - proposer.log_prob(theta2).sum()
+            )
+            if logacc > 0 or Bernoulli(probs=torch.exp(logacc)).sample().item():
+                theta, score, proposer = theta2, score2, proposer2
+            samples.append(theta.clone())
+        t2 = time.time()
+        samples_formatted = []
+        for i in tqdm(range(num_samples), desc="collect", leave=False):
+            sample_dict = {
+                "alpha": samples[i][0].item(),
+                "beta": samples[i][1:].detach().numpy(),
+            }
+            samples_formatted.append(sample_dict)
+
+        timing_info = {"compile_time": 0, "inference_time": t2 - t1}
+        return (samples_formatted, timing_info)

--- a/ppls/nmc/robust_regression.py
+++ b/ppls/nmc/robust_regression.py
@@ -7,169 +7,177 @@ from torch import tensor
 from torch.distributions import Bernoulli, Exponential, Gamma, Normal, StudentT
 from tqdm import tqdm
 
+from ..pplbench_ppl import PPLBenchPPL
 from .utils import gradients, halfspace_proposer, real_proposer
 
 
-def obtain_posterior(
-    data_train: Tuple[Any, Any], args_dict: Dict, model=None
-) -> Tuple[List, Dict]:
-    """
-    Beanmachine impmementation of logisitc regression model.
+class RobustRegression(PPLBenchPPL):
+    def obtain_posterior(
+        self, data_train: Tuple[Any, Any], args_dict: Dict, model=None
+    ) -> Tuple[List, Dict]:
+        """
+        Beanmachine impmementation of logisitc regression model.
 
-    :param data_train: tuple of np.ndarray (x_train, y_train)
-    :param args_dict: a dict of model arguments
-    :returns: samples_beanmachine(dict): posterior samples of all parameters
-    :returns: timing_info(dict): compile_time, inference_time
-    """
-    # shape of x_train: (num_features, num_samples)
-    x_train, y_train = data_train
-    y_train = tensor(y_train, dtype=torch.float32)
-    x_train = tensor(x_train, dtype=torch.float32)
-    N = int(x_train.shape[1])
-    K = int(x_train.shape[0])
-    assert y_train.shape == (N,)
-    # reshape x_train to (K+1) x N with an extra row 1 at the top
-    x_train = torch.cat((torch.ones((1, N)), x_train))
+        :param data_train: tuple of np.ndarray (x_train, y_train)
+        :param args_dict: a dict of model arguments
+        :returns: samples_beanmachine(dict): posterior samples of all parameters
+        :returns: timing_info(dict): compile_time, inference_time
+        """
+        # shape of x_train: (num_features, num_samples)
+        x_train, y_train = data_train
+        y_train = tensor(y_train, dtype=torch.float32)
+        x_train = tensor(x_train, dtype=torch.float32)
+        N = int(x_train.shape[1])
+        K = int(x_train.shape[0])
+        assert y_train.shape == (N,)
+        # reshape x_train to (K+1) x N with an extra row 1 at the top
+        x_train = torch.cat((torch.ones((1, N)), x_train))
 
-    alpha_scale, beta_scale, beta_loc, sigma_mean = args_dict["model_args"]
-    num_samples = args_dict["num_samples_nmc"]
+        alpha_scale, beta_scale, beta_loc, sigma_mean = args_dict["model_args"]
+        num_samples = args_dict["num_samples_nmc"]
 
-    prior_sigma = Exponential(tensor(1.0 / sigma_mean))
-    prior_nu = Gamma(tensor(2.0), tensor(0.1))
-    prior_beta = Normal(
-        tensor([0.0] + [float(beta_loc)] * K),
-        tensor([float(alpha_scale)] + [float(beta_scale)] * K),
-    )
-
-    class State:
-        def __init__(self, nu=None, sigma=None, beta=None):
-            # initialize reals to zero and real+ to 1
-            self.nu = tensor(1.0, requires_grad=False) if nu is None else nu
-            self.sigma = tensor(1.0, requires_grad=False) if sigma is None else sigma
-            self.beta = (
-                torch.zeros(K + 1, requires_grad=False) if beta is None else beta
-            )
-
-        def clone(self):
-            return State(self.nu.clone(), self.sigma.clone(), self.beta.clone())
-
-        def compute_score_(self):
-            self.score = prior_sigma.log_prob(self.sigma)
-            self.score += prior_nu.log_prob(self.nu)
-            self.score += prior_beta.log_prob(self.beta).sum()
-            # (K+1)x1 * (K+1)xN => (K+1)xN .sum(0) => N
-            mu = (self.beta.unsqueeze(1) * x_train).sum(axis=0)
-            self.score += StudentT(self.nu, mu, self.sigma).log_prob(y_train).sum()
-
-        def compute_nu_gradients_(self):
-            self.nu.requires_grad_(True)
-            self.compute_score_()
-            self.nu_grad, = torch.autograd.grad(self.score, self.nu, create_graph=True)
-            self.nu_hess, = torch.autograd.grad(self.nu_grad, self.nu)
-            self.nu_grad.detach_()
-            self.nu_hess.detach_()
-            self.nu.requires_grad_(False)
-
-        def compute_nu_proposer_(self):
-            # proposer for nu
-            self.compute_nu_gradients_()
-            self.nu_proposer = halfspace_proposer(self.nu, self.nu_grad, self.nu_hess)
-
-        def compute_sigma_gradients_(self):
-            self.sigma.requires_grad_(True)
-            self.compute_score_()
-            self.sigma_grad, = torch.autograd.grad(
-                self.score, self.sigma, create_graph=True
-            )
-            self.sigma_hess, = torch.autograd.grad(self.sigma_grad, self.sigma)
-            self.sigma_grad.detach_()
-            self.sigma_hess.detach_()
-            self.sigma.requires_grad_(False)
-
-        def compute_sigma_proposer_(self):
-            # proposer for sigma
-            self.compute_sigma_gradients_()
-            self.sigma_proposer = halfspace_proposer(
-                self.sigma, self.sigma_grad, self.sigma_hess
-            )
-
-        def compute_beta_gradients_(self):
-            self.beta.requires_grad_(True)
-            self.compute_score_()
-            grad, hess = gradients(self.score, self.beta)
-            self.beta_grad = grad.detach()
-            self.beta_hess = hess.detach()
-            self.beta.requires_grad_(False)
-
-        def compute_beta_proposer_(self):
-            self.compute_beta_gradients_()
-            self.beta_proposer = real_proposer(
-                self.beta, self.beta_grad, self.beta_hess
-            )
-
-    samples = []
-    t1 = time.time()
-    theta = State()
-    for _i in tqdm(range(num_samples), desc="inference", leave=False):
-        # propose nu
-        theta.compute_nu_proposer_()
-        # pyre-fixme[16]: `State` has no attribute `nu_proposer`.
-        # pyre-fixme[16]: `State` has no attribute `nu_proposer`.
-        nu = theta.nu_proposer.sample()
-        theta2 = State(nu.clone(), theta.sigma.clone(), theta.beta.clone())
-        theta2.compute_nu_proposer_()
-        logacc = (
-            # pyre-fixme[16]: `State` has no attribute `score`.
-            # pyre-fixme[16]: `State` has no attribute `score`.
-            theta2.score
-            - theta.score
-            + theta2.nu_proposer.log_prob(theta.nu)
-            - theta.nu_proposer.log_prob(theta2.nu)
+        prior_sigma = Exponential(tensor(1.0 / sigma_mean))
+        prior_nu = Gamma(tensor(2.0), tensor(0.1))
+        prior_beta = Normal(
+            tensor([0.0] + [float(beta_loc)] * K),
+            tensor([float(alpha_scale)] + [float(beta_scale)] * K),
         )
-        if logacc > 0 or Bernoulli(probs=torch.exp(logacc)).sample().item():
-            theta = theta2
-        # propose sigma
-        theta.compute_sigma_proposer_()
-        # pyre-fixme[16]: `State` has no attribute `sigma_proposer`.
-        # pyre-fixme[16]: `State` has no attribute `sigma_proposer`.
-        sigma = theta.sigma_proposer.sample()
-        theta2 = State(theta.nu.clone(), sigma.clone(), theta.beta.clone())
-        theta2.compute_sigma_proposer_()
-        logacc = (
-            theta2.score
-            - theta.score
-            + theta2.sigma_proposer.log_prob(theta.sigma)
-            - theta.sigma_proposer.log_prob(theta2.sigma)
-        )
-        if logacc > 0 or Bernoulli(probs=torch.exp(logacc)).sample().item():
-            theta = theta2
-        # propose beta
-        theta.compute_beta_proposer_()
-        # pyre-fixme[16]: `State` has no attribute `beta_proposer`.
-        # pyre-fixme[16]: `State` has no attribute `beta_proposer`.
-        beta = theta.beta_proposer.sample()
-        theta2 = State(theta.nu.clone(), theta.sigma.clone(), beta.clone())
-        theta2.compute_beta_proposer_()
-        logacc = (
-            theta2.score
-            - theta.score
-            + theta2.beta_proposer.log_prob(theta.beta)
-            - theta.beta_proposer.log_prob(theta2.beta)
-        )
-        if logacc > 0 or Bernoulli(probs=torch.exp(logacc)).sample().item():
-            theta = theta2
-        samples.append(theta.clone())
-    t2 = time.time()
-    samples_formatted = []
-    for i in tqdm(range(num_samples), desc="collect samples", leave=False):
-        theta = samples[i]
-        sample_dict = {
-            "sigma": theta.sigma.item(),
-            "nu": theta.nu.item(),
-            "alpha": theta.beta[0].item(),
-            "beta": theta.beta[1:].numpy(),
-        }
-        samples_formatted.append(sample_dict)
 
-    timing_info = {"compile_time": 0, "inference_time": t2 - t1}
-    return (samples_formatted, timing_info)
+        class State:
+            def __init__(self, nu=None, sigma=None, beta=None):
+                # initialize reals to zero and real+ to 1
+                self.nu = tensor(1.0, requires_grad=False) if nu is None else nu
+                self.sigma = (
+                    tensor(1.0, requires_grad=False) if sigma is None else sigma
+                )
+                self.beta = (
+                    torch.zeros(K + 1, requires_grad=False) if beta is None else beta
+                )
+
+            def clone(self):
+                return State(self.nu.clone(), self.sigma.clone(), self.beta.clone())
+
+            def compute_score_(self):
+                self.score = prior_sigma.log_prob(self.sigma)
+                self.score += prior_nu.log_prob(self.nu)
+                self.score += prior_beta.log_prob(self.beta).sum()
+                # (K+1)x1 * (K+1)xN => (K+1)xN .sum(0) => N
+                mu = (self.beta.unsqueeze(1) * x_train).sum(axis=0)
+                self.score += StudentT(self.nu, mu, self.sigma).log_prob(y_train).sum()
+
+            def compute_nu_gradients_(self):
+                self.nu.requires_grad_(True)
+                self.compute_score_()
+                (self.nu_grad,) = torch.autograd.grad(
+                    self.score, self.nu, create_graph=True
+                )
+                (self.nu_hess,) = torch.autograd.grad(self.nu_grad, self.nu)
+                self.nu_grad.detach_()
+                self.nu_hess.detach_()
+                self.nu.requires_grad_(False)
+
+            def compute_nu_proposer_(self):
+                # proposer for nu
+                self.compute_nu_gradients_()
+                self.nu_proposer = halfspace_proposer(
+                    self.nu, self.nu_grad, self.nu_hess
+                )
+
+            def compute_sigma_gradients_(self):
+                self.sigma.requires_grad_(True)
+                self.compute_score_()
+                (self.sigma_grad,) = torch.autograd.grad(
+                    self.score, self.sigma, create_graph=True
+                )
+                (self.sigma_hess,) = torch.autograd.grad(self.sigma_grad, self.sigma)
+                self.sigma_grad.detach_()
+                self.sigma_hess.detach_()
+                self.sigma.requires_grad_(False)
+
+            def compute_sigma_proposer_(self):
+                # proposer for sigma
+                self.compute_sigma_gradients_()
+                self.sigma_proposer = halfspace_proposer(
+                    self.sigma, self.sigma_grad, self.sigma_hess
+                )
+
+            def compute_beta_gradients_(self):
+                self.beta.requires_grad_(True)
+                self.compute_score_()
+                grad, hess = gradients(self.score, self.beta)
+                self.beta_grad = grad.detach()
+                self.beta_hess = hess.detach()
+                self.beta.requires_grad_(False)
+
+            def compute_beta_proposer_(self):
+                self.compute_beta_gradients_()
+                self.beta_proposer = real_proposer(
+                    self.beta, self.beta_grad, self.beta_hess
+                )
+
+        samples = []
+        t1 = time.time()
+        theta = State()
+        for _i in tqdm(range(num_samples), desc="inference", leave=False):
+            # propose nu
+            theta.compute_nu_proposer_()
+            # pyre-fixme[16]: `State` has no attribute `nu_proposer`.
+            # pyre-fixme[16]: `State` has no attribute `nu_proposer`.
+            nu = theta.nu_proposer.sample()
+            theta2 = State(nu.clone(), theta.sigma.clone(), theta.beta.clone())
+            theta2.compute_nu_proposer_()
+            logacc = (
+                # pyre-fixme[16]: `State` has no attribute `score`.
+                # pyre-fixme[16]: `State` has no attribute `score`.
+                theta2.score
+                - theta.score
+                + theta2.nu_proposer.log_prob(theta.nu)
+                - theta.nu_proposer.log_prob(theta2.nu)
+            )
+            if logacc > 0 or Bernoulli(probs=torch.exp(logacc)).sample().item():
+                theta = theta2
+            # propose sigma
+            theta.compute_sigma_proposer_()
+            # pyre-fixme[16]: `State` has no attribute `sigma_proposer`.
+            # pyre-fixme[16]: `State` has no attribute `sigma_proposer`.
+            sigma = theta.sigma_proposer.sample()
+            theta2 = State(theta.nu.clone(), sigma.clone(), theta.beta.clone())
+            theta2.compute_sigma_proposer_()
+            logacc = (
+                theta2.score
+                - theta.score
+                + theta2.sigma_proposer.log_prob(theta.sigma)
+                - theta.sigma_proposer.log_prob(theta2.sigma)
+            )
+            if logacc > 0 or Bernoulli(probs=torch.exp(logacc)).sample().item():
+                theta = theta2
+            # propose beta
+            theta.compute_beta_proposer_()
+            # pyre-fixme[16]: `State` has no attribute `beta_proposer`.
+            # pyre-fixme[16]: `State` has no attribute `beta_proposer`.
+            beta = theta.beta_proposer.sample()
+            theta2 = State(theta.nu.clone(), theta.sigma.clone(), beta.clone())
+            theta2.compute_beta_proposer_()
+            logacc = (
+                theta2.score
+                - theta.score
+                + theta2.beta_proposer.log_prob(theta.beta)
+                - theta.beta_proposer.log_prob(theta2.beta)
+            )
+            if logacc > 0 or Bernoulli(probs=torch.exp(logacc)).sample().item():
+                theta = theta2
+            samples.append(theta.clone())
+        t2 = time.time()
+        samples_formatted = []
+        for i in tqdm(range(num_samples), desc="collect samples", leave=False):
+            theta = samples[i]
+            sample_dict = {
+                "sigma": theta.sigma.item(),
+                "nu": theta.nu.item(),
+                "alpha": theta.beta[0].item(),
+                "beta": theta.beta[1:].numpy(),
+            }
+            samples_formatted.append(sample_dict)
+
+        timing_info = {"compile_time": 0, "inference_time": t2 - t1}
+        return (samples_formatted, timing_info)

--- a/ppls/numpyro/logistic_regression.py
+++ b/ppls/numpyro/logistic_regression.py
@@ -14,6 +14,8 @@ from numpyro.distributions import Bernoulli, Normal
 from numpyro.mcmc import MCMC, NUTS
 from numpyro.primitives import sample
 
+from ..pplbench_ppl import PPLBenchPPL
+
 
 def logistic_regression(x, y, model_args):
     ndims = np.shape(x)[-1]
@@ -24,46 +26,47 @@ def logistic_regression(x, y, model_args):
     return sample("y", Bernoulli(logits=x @ beta + alpha), obs=y)
 
 
-def obtain_posterior(data_train, args_dict, model=None):
-    """
-    Numpyro implementation of logistic regression model.
+class LogisticRegression(PPLBenchPPL):
+    def obtain_posterior(self, data_train, args_dict, model=None):
+        """
+        Numpyro implementation of logistic regression model.
 
-    Inputs:
-    - data_train(tuple of np.ndarray): x_train, y_train
-    - args_dict: a dict of model arguments
-    Returns:
-    - samples_numpyro(dict): posterior samples of all parameters
-    - timing_info(dict): compile_time, inference_time
-    """
-    model_args = args_dict["model_args"]
+        Inputs:
+        - data_train(tuple of np.ndarray): x_train, y_train
+        - args_dict: a dict of model arguments
+        Returns:
+        - samples_numpyro(dict): posterior samples of all parameters
+        - timing_info(dict): compile_time, inference_time
+        """
+        model_args = args_dict["model_args"]
 
-    # x_train is (num_features, num_observations)
-    x_train, y_train = data_train
-    # x_train is (num_observations, num_features)
-    x_train = x_train.T
-    start_time = time.time()
+        # x_train is (num_features, num_observations)
+        x_train, y_train = data_train
+        # x_train is (num_observations, num_features)
+        x_train = x_train.T
+        start_time = time.time()
 
-    num_warmup = 500
-    num_samples = args_dict["num_samples_numpyro"] - num_warmup
+        num_warmup = 500
+        num_samples = args_dict["num_samples_numpyro"] - num_warmup
 
-    assert num_samples > 0
-    # Run inference to generate samples from the posterior
-    kernel = NUTS(model=logistic_regression)
-    mcmc = MCMC(kernel, num_warmup=num_warmup, num_samples=num_samples)
-    mcmc.run(random.PRNGKey(1), x=x_train, y=y_train, model_args=model_args)
-    samples_numpyro = mcmc.get_samples()
-    elapsed_time_sample_pyro = time.time() - start_time
+        assert num_samples > 0
+        # Run inference to generate samples from the posterior
+        kernel = NUTS(model=logistic_regression)
+        mcmc = MCMC(kernel, num_warmup=num_warmup, num_samples=num_samples)
+        mcmc.run(random.PRNGKey(1), x=x_train, y=y_train, model_args=model_args)
+        samples_numpyro = mcmc.get_samples()
+        elapsed_time_sample_pyro = time.time() - start_time
 
-    # repackage samples into shape required by PPLBench
-    samples = []
+        # repackage samples into shape required by PPLBench
+        samples = []
 
-    for i in range(num_samples):
-        sample_dict = {}
-        sample_dict["alpha"] = onp.asarray(samples_numpyro["alpha"][i])
-        sample_dict["beta"] = onp.asarray(samples_numpyro["beta"][i])
-        samples.append(sample_dict)
-    timing_info = {
-        "compile_time": 0,
-        "inference_time": elapsed_time_sample_pyro,
-    }  # no compiliation for pyro
-    return (samples, timing_info)
+        for i in range(num_samples):
+            sample_dict = {}
+            sample_dict["alpha"] = onp.asarray(samples_numpyro["alpha"][i])
+            sample_dict["beta"] = onp.asarray(samples_numpyro["beta"][i])
+            samples.append(sample_dict)
+        timing_info = {
+            "compile_time": 0,
+            "inference_time": elapsed_time_sample_pyro,
+        }  # no compiliation for pyro
+        return (samples, timing_info)

--- a/ppls/pplbench_ppl.py
+++ b/ppls/pplbench_ppl.py
@@ -1,0 +1,19 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+from abc import ABCMeta, abstractmethod
+from typing import Dict, List, Tuple
+
+
+class PPLBenchPPL(object, metaclass=ABCMeta):
+    @abstractmethod
+    def obtain_posterior(self, data_train, args_dict, model=None) -> Tuple[List, Dict]:
+        """
+        Returns posterior samples and timing info
+        :param data_train: data to train the model on
+        :param args_dict: model specific parameters like number of observations etc
+
+        :returns: Tuple of
+        1) posterior_samples: List where each element is a dictionary with key as
+        name of random variable and value as sample.
+        2) Timing Info: {"compile_time": ..., "inference_time": ...}
+        """
+        raise NotImplementedError("PPLBenchPPL must implement obtain_posterior.")

--- a/ppls/pymc3/crowd_sourced_annotation.py
+++ b/ppls/pymc3/crowd_sourced_annotation.py
@@ -8,70 +8,77 @@ import numpy as np
 # pyre-fixme[21]: Could not find `pymc3`.
 import pymc3 as pm
 
+from ..pplbench_ppl import PPLBenchPPL
 
-def obtain_posterior(data_train, args_dict, model=None):
-    """
-    PyMC3 implementation of crowdsourced annotation model
 
-    Inputs:
-    - data_train(tuple of np.ndarray): vector_y, vector_J_i, num_labels
-    - args_dict: a dict of model arguments
-    Returns:
-    - samples(dict): posterior samples of all parameters
-    - timing_info(dict): compile_time, inference_time
-    """
-    vector_y, vector_J_i, num_labels = data_train
-    n_labelers = int(args_dict["k"])
-    n_items = len(num_labels)
-    K, labeler_rate, expected_correctness, concentration = args_dict["model_args"]
-    num_samples = args_dict["num_samples_pymc3"]
-    # item array for pymc3; change from list-of-lengths format of num_labels
-    # to list-of-items associated with each label and labeler in vector_y, vector_J_i
-    item = []
-    for i in range(len(num_labels)):
-        item.extend(np.repeat(i, num_labels[i]))
-    # set prior that each labeler on average has 50% chance of getting true label
-    alpha = ((1 - expected_correctness) / (K - 1)) * np.ones([K, K]) + (
-        expected_correctness - (1 - expected_correctness) / (K - 1)
-    ) * np.eye(K)
-    alpha *= concentration
-    # set prior that each item is equally likely to be in any given label
-    beta = 1 / K * np.ones(K)
-    # sample the parameter posteriors, time it
-    start_time = time.time()
+class CrowdSourcedAnnotation(PPLBenchPPL):
+    def obtain_posterior(self, data_train, args_dict, model=None):
+        """
+        PyMC3 implementation of crowdsourced annotation model
 
-    # Define model and sample
-    if args_dict["inference_type"] == "mcmc":
-        with pm.Model():
-            # sample a true class z for each item
-            pi = pm.Dirichlet("pi", beta)
-            z = pm.Categorical("z", p=pi, shape=n_items)
-            # sample confusion matrices theta for labelers from this dirichlet prior
-            theta = pm.Dirichlet("theta", a=alpha, shape=(n_labelers, K, K))
-            # likelihood
-            pm.Categorical(
-                "labels", p=theta[vector_J_i, z[item]], observed=vector_y, shape=n_items
-            )
-            elapsed_time_compile_pymc3 = time.time() - start_time
-            start_time = time.time()
-            samples_pymc3 = pm.sample(
-                num_samples, cores=1, chains=1, discard_tuned_samples=False
-            )
+        Inputs:
+        - data_train(tuple of np.ndarray): vector_y, vector_J_i, num_labels
+        - args_dict: a dict of model arguments
+        Returns:
+        - samples(dict): posterior samples of all parameters
+        - timing_info(dict): compile_time, inference_time
+        """
+        vector_y, vector_J_i, num_labels = data_train
+        n_labelers = int(args_dict["k"])
+        n_items = len(num_labels)
+        K, labeler_rate, expected_correctness, concentration = args_dict["model_args"]
+        num_samples = args_dict["num_samples_pymc3"]
+        # item array for pymc3; change from list-of-lengths format
+        # of num_labels to list-of-items associated with each label
+        # and labeler in vector_y, vector_J_i
+        item = []
+        for i in range(len(num_labels)):
+            item.extend(np.repeat(i, num_labels[i]))
+        # set prior that each labeler on average has 50% chance of getting true label
+        alpha = ((1 - expected_correctness) / (K - 1)) * np.ones([K, K]) + (
+            expected_correctness - (1 - expected_correctness) / (K - 1)
+        ) * np.eye(K)
+        alpha *= concentration
+        # set prior that each item is equally likely to be in any given label
+        beta = 1 / K * np.ones(K)
+        # sample the parameter posteriors, time it
+        start_time = time.time()
 
-    elif args_dict["inference_type"] == "vi":
-        raise NotImplementedError
+        # Define model and sample
+        if args_dict["inference_type"] == "mcmc":
+            with pm.Model():
+                # sample a true class z for each item
+                pi = pm.Dirichlet("pi", beta)
+                z = pm.Categorical("z", p=pi, shape=n_items)
+                # sample confusion matrices theta for labelers from this dirichlet prior
+                theta = pm.Dirichlet("theta", a=alpha, shape=(n_labelers, K, K))
+                # likelihood
+                pm.Categorical(
+                    "labels",
+                    p=theta[vector_J_i, z[item]],
+                    observed=vector_y,
+                    shape=n_items,
+                )
+                elapsed_time_compile_pymc3 = time.time() - start_time
+                start_time = time.time()
+                samples_pymc3 = pm.sample(
+                    num_samples, cores=1, chains=1, discard_tuned_samples=False
+                )
 
-    elapsed_time_sample_pymc3 = time.time() - start_time
-    # repackage samples into shape required by PPLBench
-    samples = []
-    for i in range(0, int(args_dict["num_samples_pymc3"])):
-        sample_dict = {}
-        for parameter in ["theta", "pi"]:
-            sample_dict[parameter] = samples_pymc3[parameter][i]
-        samples.append(sample_dict)
-    timing_info = {
-        "compile_time": elapsed_time_compile_pymc3,
-        "inference_time": elapsed_time_sample_pymc3,
-    }
+        elif args_dict["inference_type"] == "vi":
+            raise NotImplementedError
 
-    return (samples, timing_info)
+        elapsed_time_sample_pymc3 = time.time() - start_time
+        # repackage samples into shape required by PPLBench
+        samples = []
+        for i in range(0, int(args_dict["num_samples_pymc3"])):
+            sample_dict = {}
+            for parameter in ["theta", "pi"]:
+                sample_dict[parameter] = samples_pymc3[parameter][i]
+            samples.append(sample_dict)
+        timing_info = {
+            "compile_time": elapsed_time_compile_pymc3,
+            "inference_time": elapsed_time_sample_pymc3,
+        }
+
+        return (samples, timing_info)

--- a/ppls/pymc3/hidden_markov.py
+++ b/ppls/pymc3/hidden_markov.py
@@ -10,101 +10,104 @@ import pymc3 as pm
 import torch
 from numpy import array
 
+from ..pplbench_ppl import PPLBenchPPL
+
 
 # from torch import tensor
 
 
-def obtain_posterior(data_train, args_dict, model=None):
-    """
-    PyMC3 impmementation of HMM prediction.
+class HiddenMarkov(PPLBenchPPL):
+    def obtain_posterior(self, data_train, args_dict, model=None):
+        """
+        PyMC3 impmementation of HMM prediction.
 
-    :param data_train:
-    :param args_dict: a dict of model arguments
-    :returns: samples_beanmachine(dict): posterior samples of all parameters
-    :returns: timing_info(dict): compile_time, inference_time
-    """
-    # true_theta = model["theta"]
-    # true_theta = torch.stack(true_theta).numpy()
+        :param data_train:
+        :param args_dict: a dict of model arguments
+        :returns: samples_beanmachine(dict): posterior samples of all parameters
+        :returns: timing_info(dict): compile_time, inference_time
+        """
+        # true_theta = model["theta"]
+        # true_theta = torch.stack(true_theta).numpy()
 
-    N = int(args_dict["n"])
-    K = int(args_dict["k"])
-    concentration, mu_loc, mu_scale, sigma_shape, sigma_rate, observe_model = list(
-        map(float, args_dict["model_args"])
-    )
-    num_samples = int(args_dict["num_samples"])
-    observations = data_train
-    observations = torch.stack(observations).numpy()
-
-    start_time = time.time()
-
-    Xs = {}
-    Ys = {}
-    with pm.Model():
-        if observe_model:
-            theta = pm.Dirichlet(
-                "theta",
-                a=np.ones(K) * concentration / K,
-                shape=(K, K),
-                observed=model["theta"].numpy(),
-            )
-            mus = pm.Normal(
-                "mus", mu_loc, mu_scale, shape=(K,), observed=model["mus"].numpy()
-            )
-            sigmas = pm.Gamma(
-                "sigmas",
-                sigma_shape,
-                sigma_rate,
-                shape=(K,),
-                observed=model["sigmas"].numpy(),
-            )
-        else:
-            theta = pm.Dirichlet(
-                "theta", a=np.ones(K) * concentration / K, shape=(K, K)
-            )
-            mus = pm.Normal("mus", mu_loc, mu_scale, shape=(K,))
-            sigmas = pm.Gamma("sigmas", sigma_shape, sigma_rate, shape=(K,))
-
-        Xs[0] = pm.Categorical("X[0]", p=array([1] + [0] * (K - 1)), observed=0)
-        Ys[0] = pm.Normal(
-            "Y[0]", mu=mus[Xs[0]], sigma=sigmas[Xs[0]], observed=observations[0]
+        N = int(args_dict["n"])
+        K = int(args_dict["k"])
+        concentration, mu_loc, mu_scale, sigma_shape, sigma_rate, observe_model = list(
+            map(float, args_dict["model_args"])
         )
-        for i in range(1, N):
-            Xs[i] = pm.Categorical("X[" + str(i) + "]", p=theta[Xs[i - 1]])
-            Ys[i] = pm.Normal(
-                "Y[" + str(i) + "]",
-                mu=mus[Xs[i]],
-                sigma=sigmas[Xs[i]],
-                observed=observations[i],
-            )
+        num_samples = int(args_dict["num_samples"])
+        observations = data_train
+        observations = torch.stack(observations).numpy()
 
-        elapsed_time_compile_pymc3 = time.time() - start_time
         start_time = time.time()
-        samples_pymc3 = pm.sample(
-            draws=0,
-            chains=1,
-            cores=1,
-            tune=num_samples,
-            discard_tuned_samples=False,
-            compute_convergence_checks=False,
-        )
 
-    elapsed_time_sample_pymc3 = time.time() - start_time
+        Xs = {}
+        Ys = {}
+        with pm.Model():
+            if observe_model:
+                theta = pm.Dirichlet(
+                    "theta",
+                    a=np.ones(K) * concentration / K,
+                    shape=(K, K),
+                    observed=model["theta"].numpy(),
+                )
+                mus = pm.Normal(
+                    "mus", mu_loc, mu_scale, shape=(K,), observed=model["mus"].numpy()
+                )
+                sigmas = pm.Gamma(
+                    "sigmas",
+                    sigma_shape,
+                    sigma_rate,
+                    shape=(K,),
+                    observed=model["sigmas"].numpy(),
+                )
+            else:
+                theta = pm.Dirichlet(
+                    "theta", a=np.ones(K) * concentration / K, shape=(K, K)
+                )
+                mus = pm.Normal("mus", mu_loc, mu_scale, shape=(K,))
+                sigmas = pm.Gamma("sigmas", sigma_shape, sigma_rate, shape=(K,))
 
-    # repackage samples into shape required by PPLBench
-    xn1str = "X[" + str(N - 1) + "]"
-    samples = []
-    for i in range(num_samples):
-        result = {}
-        if not observe_model:
-            result["theta"] = samples_pymc3["theta"][i]
-            result["mus"] = samples_pymc3["mus"][i]
-            result["sigmas"] = samples_pymc3["sigmas"][i]
-        result[xn1str] = samples_pymc3["X[" + str(N - 1) + "]"][i]
-        samples.append(result)
+            Xs[0] = pm.Categorical("X[0]", p=array([1] + [0] * (K - 1)), observed=0)
+            Ys[0] = pm.Normal(
+                "Y[0]", mu=mus[Xs[0]], sigma=sigmas[Xs[0]], observed=observations[0]
+            )
+            for i in range(1, N):
+                Xs[i] = pm.Categorical("X[" + str(i) + "]", p=theta[Xs[i - 1]])
+                Ys[i] = pm.Normal(
+                    "Y[" + str(i) + "]",
+                    mu=mus[Xs[i]],
+                    sigma=sigmas[Xs[i]],
+                    observed=observations[i],
+                )
 
-    timing_info = {
-        "compile_time": elapsed_time_compile_pymc3,
-        "inference_time": elapsed_time_sample_pymc3,
-    }
+            elapsed_time_compile_pymc3 = time.time() - start_time
+            start_time = time.time()
+            samples_pymc3 = pm.sample(
+                draws=0,
+                chains=1,
+                cores=1,
+                tune=num_samples,
+                discard_tuned_samples=False,
+                compute_convergence_checks=False,
+            )
 
-    return (samples, timing_info)
+        elapsed_time_sample_pymc3 = time.time() - start_time
+
+        # repackage samples into shape required by PPLBench
+        xn1str = "X[" + str(N - 1) + "]"
+        samples = []
+        for i in range(num_samples):
+            result = {}
+            if not observe_model:
+                result["theta"] = samples_pymc3["theta"][i]
+                result["mus"] = samples_pymc3["mus"][i]
+                result["sigmas"] = samples_pymc3["sigmas"][i]
+            result[xn1str] = samples_pymc3["X[" + str(N - 1) + "]"][i]
+            samples.append(result)
+
+        timing_info = {
+            "compile_time": elapsed_time_compile_pymc3,
+            "inference_time": elapsed_time_sample_pymc3,
+        }
+
+        return (samples, timing_info)

--- a/ppls/pymc3/logistic_regression.py
+++ b/ppls/pymc3/logistic_regression.py
@@ -6,51 +6,58 @@ import time
 # pyre-fixme[21]: Could not find `pymc3`.
 import pymc3 as pm
 
+from ..pplbench_ppl import PPLBenchPPL
 
-def obtain_posterior(data_train, args_dict, model=None):
-    """
-    PyMC3 implementation of logistic regression model.
 
-    Inputs:
-    - data_train(tuple of np.ndarray): x_train, y_train
-    - args_dict: a dict of model arguments
-    Returns:
-    - samples(dict): posterior samples of all parameters
-    - timing_info(dict): compile_time, inference_time
-    """
-    x_train, y_train = data_train
-    K = int(x_train.shape[0])
-    alpha_scale, beta_scale, beta_loc, _ = args_dict["model_args"]
-    num_samples = int(args_dict["num_samples_pymc3"])
+class LogisticRegression(PPLBenchPPL):
+    def obtain_posterior(self, data_train, args_dict, model=None):
+        """
+        PyMC3 implementation of logistic regression model.
 
-    # Define model and sample
-    if args_dict["inference_type"] == "mcmc":
-        start_time = time.time()
-        with pm.Model():
-            alpha = pm.Normal("alpha", mu=0, sigma=alpha_scale)
-            beta = pm.Normal("beta", mu=beta_loc, sigma=beta_scale, shape=K)
-            mean = (alpha + x_train.T * beta).T
-            pm.Bernoulli("y_observed", logit_p=mean, observed=y_train)
-            elapsed_time_compile_pymc3 = time.time() - start_time
+        Inputs:
+        - data_train(tuple of np.ndarray): x_train, y_train
+        - args_dict: a dict of model arguments
+        Returns:
+        - samples(dict): posterior samples of all parameters
+        - timing_info(dict): compile_time, inference_time
+        """
+        x_train, y_train = data_train
+        K = int(x_train.shape[0])
+        alpha_scale, beta_scale, beta_loc, _ = args_dict["model_args"]
+        num_samples = int(args_dict["num_samples_pymc3"])
+
+        # Define model and sample
+        if args_dict["inference_type"] == "mcmc":
             start_time = time.time()
-            samples_pymc3 = pm.sample(
-                num_samples, cores=1, chains=1, tune=200, discard_tuned_samples=False
-            )
+            with pm.Model():
+                alpha = pm.Normal("alpha", mu=0, sigma=alpha_scale)
+                beta = pm.Normal("beta", mu=beta_loc, sigma=beta_scale, shape=K)
+                mean = (alpha + x_train.T * beta).T
+                pm.Bernoulli("y_observed", logit_p=mean, observed=y_train)
+                elapsed_time_compile_pymc3 = time.time() - start_time
+                start_time = time.time()
+                samples_pymc3 = pm.sample(
+                    num_samples,
+                    cores=1,
+                    chains=1,
+                    tune=200,
+                    discard_tuned_samples=False,
+                )
 
-    elif args_dict["inference_type"] == "vi":
-        raise NotImplementedError
+        elif args_dict["inference_type"] == "vi":
+            raise NotImplementedError
 
-    elapsed_time_sample_pymc3 = time.time() - start_time
-    # repackage samples into shape required by PPLBench
-    samples = []
-    for i in range(0, int(args_dict["num_samples_pymc3"])):
-        sample_dict = {}
-        for parameter in ["alpha", "beta"]:
-            sample_dict[parameter] = samples_pymc3[parameter][i]
-        samples.append(sample_dict)
-    timing_info = {
-        "compile_time": elapsed_time_compile_pymc3,
-        "inference_time": elapsed_time_sample_pymc3,
-    }
+        elapsed_time_sample_pymc3 = time.time() - start_time
+        # repackage samples into shape required by PPLBench
+        samples = []
+        for i in range(0, int(args_dict["num_samples_pymc3"])):
+            sample_dict = {}
+            for parameter in ["alpha", "beta"]:
+                sample_dict[parameter] = samples_pymc3[parameter][i]
+            samples.append(sample_dict)
+        timing_info = {
+            "compile_time": elapsed_time_compile_pymc3,
+            "inference_time": elapsed_time_sample_pymc3,
+        }
 
-    return (samples, timing_info)
+        return (samples, timing_info)

--- a/ppls/pymc3/noisy_or_topic.py
+++ b/ppls/pymc3/noisy_or_topic.py
@@ -12,78 +12,81 @@ import pymc3 as pm
 # pyre-fixme[21]: Could not find `theano`.
 import theano.tensor as t
 
+from ..pplbench_ppl import PPLBenchPPL
 
-def obtain_posterior(data_train, args_dict, model=None):
-    """
-    PyMC3 implementation of noisy-or topic model
 
-    Inputs:
-    - data_train(tuple of np.ndarray): graph, words
-    - args_dict: a dict of model arguments
-    Returns:
-    - samples_jags(dict): posterior samples of all parameters
-    - timing_info(dict): compile_time, inference_time
-    """
-    graph = model
-    words = data_train
-    K = int(args_dict["k"])
-    word_fraction = (args_dict["model_args"])[3]
-    T = int(K * (1 - word_fraction))
-    assert len(words.shape) == 1
-    num_samples = int(args_dict["num_samples_pymc3"])
-    nodearray = np.concatenate([np.zeros(T), words])
-    prob = np.zeros_like(nodearray)
-    nodearray = list(nodearray)
-    prob = list(prob)
-    # sample the parameter posteriors, time it
-    start_time = time.time()
-    # Define model and sample
-    if args_dict["inference_type"] == "mcmc":
-        with pm.Model():
-            # traverse through nodes
-            for node in range(K):
-                # leak node
-                if node == 0:
-                    nodearray[node] = 1
-                else:
-                    # compute the weighted sum of parent activations
-                    parent_accumulator = t.zeros(1)
-                    for par, wt in enumerate(graph[:, node]):
-                        if wt:
-                            parent_accumulator += nodearray[par] * wt
-                    prob[node] = pm.Deterministic(
-                        f"prob_{node}", 1 - t.exp(-t.sum(parent_accumulator))
-                    )
-                    # topics are not observed; sample them and update the nodearray
-                    if node < T:
-                        nodearray[node] = pm.Bernoulli(f"node_{node}", p=prob[node])
-                    # words are observed
+class NoisyOrTopic(PPLBenchPPL):
+    def obtain_posterior(self, data_train, args_dict, model=None):
+        """
+        PyMC3 implementation of noisy-or topic model
+
+        Inputs:
+        - data_train(tuple of np.ndarray): graph, words
+        - args_dict: a dict of model arguments
+        Returns:
+        - samples_jags(dict): posterior samples of all parameters
+        - timing_info(dict): compile_time, inference_time
+        """
+        graph = model
+        words = data_train
+        K = int(args_dict["k"])
+        word_fraction = (args_dict["model_args"])[3]
+        T = int(K * (1 - word_fraction))
+        assert len(words.shape) == 1
+        num_samples = int(args_dict["num_samples_pymc3"])
+        nodearray = np.concatenate([np.zeros(T), words])
+        prob = np.zeros_like(nodearray)
+        nodearray = list(nodearray)
+        prob = list(prob)
+        # sample the parameter posteriors, time it
+        start_time = time.time()
+        # Define model and sample
+        if args_dict["inference_type"] == "mcmc":
+            with pm.Model():
+                # traverse through nodes
+                for node in range(K):
+                    # leak node
+                    if node == 0:
+                        nodearray[node] = 1
                     else:
-                        pm.Bernoulli(
-                            f"node_{node}", p=prob[node], observed=nodearray[node]
+                        # compute the weighted sum of parent activations
+                        parent_accumulator = t.zeros(1)
+                        for par, wt in enumerate(graph[:, node]):
+                            if wt:
+                                parent_accumulator += nodearray[par] * wt
+                        prob[node] = pm.Deterministic(
+                            f"prob_{node}", 1 - t.exp(-(t.sum(parent_accumulator)))
                         )
-            elapsed_time_compile_pymc3 = time.time() - start_time
-            # Start sampling process
-            start_time = time.time()
-            samples_pymc3 = pm.sample(
-                num_samples, cores=1, chains=1, discard_tuned_samples=False
-            )
-    elif args_dict["inference_type"] == "vi":
-        raise NotImplementedError
-    parameters = [f"node_{i}" for i in range(1, T)]
-    elapsed_time_sample_pymc3 = time.time() - start_time
-    # repackage samples into shape required by PPLBench
-    samples = []
-    for i in range(0, num_samples):
-        sample_dict = {}
-        sample_dict["node"] = np.zeros(T)
-        sample_dict["node"][0] = 1
-        for nodeid, parameter in enumerate(parameters):
-            sample_dict["node"][nodeid + 1] = samples_pymc3[parameter][i]
-        samples.append(sample_dict)
-    timing_info = {
-        "compile_time": elapsed_time_compile_pymc3,
-        "inference_time": elapsed_time_sample_pymc3,
-    }
+                        # topics are not observed; sample them and update the nodearray
+                        if node < T:
+                            nodearray[node] = pm.Bernoulli(f"node_{node}", p=prob[node])
+                        # words are observed
+                        else:
+                            pm.Bernoulli(
+                                f"node_{node}", p=prob[node], observed=nodearray[node]
+                            )
+                elapsed_time_compile_pymc3 = time.time() - start_time
+                # Start sampling process
+                start_time = time.time()
+                samples_pymc3 = pm.sample(
+                    num_samples, cores=1, chains=1, discard_tuned_samples=False
+                )
+        elif args_dict["inference_type"] == "vi":
+            raise NotImplementedError
+        parameters = [f"node_{i}" for i in range(1, T)]
+        elapsed_time_sample_pymc3 = time.time() - start_time
+        # repackage samples into shape required by PPLBench
+        samples = []
+        for i in range(0, num_samples):
+            sample_dict = {}
+            sample_dict["node"] = np.zeros(T)
+            sample_dict["node"][0] = 1
+            for nodeid, parameter in enumerate(parameters):
+                sample_dict["node"][nodeid + 1] = samples_pymc3[parameter][i]
+            samples.append(sample_dict)
+        timing_info = {
+            "compile_time": elapsed_time_compile_pymc3,
+            "inference_time": elapsed_time_sample_pymc3,
+        }
 
-    return (samples, timing_info)
+        return (samples, timing_info)

--- a/ppls/pymc3/robust_regression.py
+++ b/ppls/pymc3/robust_regression.py
@@ -6,53 +6,56 @@ import time
 # pyre-fixme[21]: Could not find `pymc3`.
 import pymc3 as pm
 
+from ..pplbench_ppl import PPLBenchPPL
 
-def obtain_posterior(data_train, args_dict, model=None):
-    """
-    PyMC3 implementation of robust regression model.
 
-    Inputs:
-    - data_train(tuple of np.ndarray): x_train, y_train
-    - args_dict: a dict of model arguments
-    Returns:
-    - samples(dict): posterior samples of all parameters
-    - timing_info(dict): compile_time, inference_time
-    """
-    x_train, y_train = data_train
-    K = int(x_train.shape[0])
-    alpha_scale, beta_scale, beta_loc, sigma_mean = args_dict["model_args"]
-    num_samples = int(args_dict["num_samples_pymc3"])
+class RobustRegression(PPLBenchPPL):
+    def obtain_posterior(self, data_train, args_dict, model=None):
+        """
+        PyMC3 implementation of robust regression model.
 
-    # Define model and sample
-    if args_dict["inference_type"] == "mcmc":
-        start_time = time.time()
-        with pm.Model():
-            alpha = pm.Normal("alpha", mu=0, sigma=alpha_scale)
-            beta = pm.Normal("beta", mu=beta_loc, sigma=beta_scale, shape=K)
-            sigma = pm.Exponential("sigma", lam=1.0 / sigma_mean)
-            nu = pm.Gamma("nu", alpha=2, beta=10)
-            mean = (alpha + x_train.T * beta).T
-            pm.StudentT("y_observed", nu=nu, mu=mean, sigma=sigma, observed=y_train)
-            elapsed_time_compile_pymc3 = time.time() - start_time
+        Inputs:
+        - data_train(tuple of np.ndarray): x_train, y_train
+        - args_dict: a dict of model arguments
+        Returns:
+        - samples(dict): posterior samples of all parameters
+        - timing_info(dict): compile_time, inference_time
+        """
+        x_train, y_train = data_train
+        K = int(x_train.shape[0])
+        alpha_scale, beta_scale, beta_loc, sigma_mean = args_dict["model_args"]
+        num_samples = int(args_dict["num_samples_pymc3"])
+
+        # Define model and sample
+        if args_dict["inference_type"] == "mcmc":
             start_time = time.time()
-            samples_pymc3 = pm.sample(
-                num_samples, cores=1, chains=1, discard_tuned_samples=False
-            )
+            with pm.Model():
+                alpha = pm.Normal("alpha", mu=0, sigma=alpha_scale)
+                beta = pm.Normal("beta", mu=beta_loc, sigma=beta_scale, shape=K)
+                sigma = pm.Exponential("sigma", lam=1.0 / sigma_mean)
+                nu = pm.Gamma("nu", alpha=2, beta=10)
+                mean = (alpha + x_train.T * beta).T
+                pm.StudentT("y_observed", nu=nu, mu=mean, sigma=sigma, observed=y_train)
+                elapsed_time_compile_pymc3 = time.time() - start_time
+                start_time = time.time()
+                samples_pymc3 = pm.sample(
+                    num_samples, cores=1, chains=1, discard_tuned_samples=False
+                )
 
-    elif args_dict["inference_type"] == "vi":
-        raise NotImplementedError
+        elif args_dict["inference_type"] == "vi":
+            raise NotImplementedError
 
-    elapsed_time_sample_pymc3 = time.time() - start_time
-    # repackage samples into shape required by PPLBench
-    samples = []
-    for i in range(0, int(args_dict["num_samples_pymc3"])):
-        sample_dict = {}
-        for parameter in ["alpha", "beta", "nu", "sigma"]:
-            sample_dict[parameter] = samples_pymc3[parameter][i]
-        samples.append(sample_dict)
-    timing_info = {
-        "compile_time": elapsed_time_compile_pymc3,
-        "inference_time": elapsed_time_sample_pymc3,
-    }
+        elapsed_time_sample_pymc3 = time.time() - start_time
+        # repackage samples into shape required by PPLBench
+        samples = []
+        for i in range(0, int(args_dict["num_samples_pymc3"])):
+            sample_dict = {}
+            for parameter in ["alpha", "beta", "nu", "sigma"]:
+                sample_dict[parameter] = samples_pymc3[parameter][i]
+            samples.append(sample_dict)
+        timing_info = {
+            "compile_time": elapsed_time_compile_pymc3,
+            "inference_time": elapsed_time_sample_pymc3,
+        }
 
-    return (samples, timing_info)
+        return (samples, timing_info)

--- a/ppls/pyro/hidden_markov.py
+++ b/ppls/pyro/hidden_markov.py
@@ -9,7 +9,9 @@ import pyro
 import pyro.distributions as dist
 import torch
 import torch.tensor as tensor
-from pyro.infer.mcmc import MCMC, NUTS
+from pyro.infer.mcmc.api import MCMC, NUTS
+
+from ..pplbench_ppl import PPLBenchPPL
 
 
 def hmm_model(K, N, observations, model_args, model):
@@ -54,64 +56,66 @@ def hmm_model(K, N, observations, model_args, model):
         )
 
 
-def obtain_posterior(
-    data_train: List, args_dict: Dict, model=None
-) -> Tuple[List, Dict]:
-    """
-    Pyro impmementation of HMM prediction.
+class HiddenMarkov(PPLBenchPPL):
+    def obtain_posterior(
+        self, data_train: List, args_dict: Dict, model=None
+    ) -> Tuple[List, Dict]:
+        """
+        Pyro impmementation of HMM prediction.
 
-    :param data_train:
-    :param args_dict: a dict of model arguments
-    :returns: samples_numpyro(dict): posterior samples of all parameters
-    :returns: timing_info(dict): compile_time, inference_time
-    """
+        :param data_train:
+        :param args_dict: a dict of model arguments
+        :returns: samples_numpyro(dict): posterior samples of all parameters
+        :returns: timing_info(dict): compile_time, inference_time
+        """
+        assert pyro.__version__.startswith("0.4.1")
 
-    N = int(args_dict["n"])
-    K = int(args_dict["k"])
-    num_samples = int(args_dict["num_samples_pyro"])
-    num_warmup = 50
-    observations = data_train
-    # observations = torch.stack(observations).numpy()
-    concentration, mu_loc, mu_scale, sigma_shape, sigma_scale, observe_model = list(
-        map(float, args_dict["model_args"])
-    )
+        N = int(args_dict["n"])
+        K = int(args_dict["k"])
+        num_samples = int(args_dict["num_samples_pyro"])
+        num_warmup = 50
+        observations = data_train
+        # observations = torch.stack(observations).numpy()
+        concentration, mu_loc, mu_scale, sigma_shape, sigma_scale, observe_model = list(
+            map(float, args_dict["model_args"])
+        )
 
-    assert num_samples - num_warmup > 0
+        assert num_samples - num_warmup > 0
 
-    # Run NUTS
-    start_time = time.time()
-    nuts_kernel = NUTS(model=hmm_model)
-    mcmc = MCMC(
-        kernel=nuts_kernel,
-        num_samples=num_samples - num_warmup,
-        warmup_steps=num_warmup,
-        num_chains=1,
-    )
-    mcmc.run(
-        K=K,
-        N=N,
-        observations=observations,
-        model_args=args_dict["model_args"],
-        model=model,
-    )
-    samples_pyro = mcmc.get_samples()
-    elapsed_time_sample_numpyro = time.time() - start_time
-    # repackage samples into shape required by PPLBench
-    samples = []
+        # Run NUTS
+        start_time = time.time()
+        nuts_kernel = NUTS(model=hmm_model)
+        mcmc = MCMC(
+            kernel=nuts_kernel,
+            num_samples=num_samples - num_warmup,
+            warmup_steps=num_warmup,
+            num_chains=1,
+        )
+        mcmc.run(
+            K=K,
+            N=N,
+            observations=observations,
+            model_args=args_dict["model_args"],
+            model=model,
+        )
+        samples_pyro = mcmc.get_samples()
+        elapsed_time_sample_numpyro = time.time() - start_time
+        # repackage samples into shape required by PPLBench
+        samples = []
 
-    for i in range(num_samples):
-        result = {}
-        if not observe_model:
-            result["theta"] = samples_pyro["theta"][i].numpy()
-            result["mus"] = samples_pyro["mus"][i]
-            result["sigmas"] = samples_pyro["sigmas"][i]
+        for i in range(num_samples):
+            result = {}
+            if not observe_model:
+                result["theta"] = samples_pyro["theta"][i].numpy()
+                result["mus"] = samples_pyro["mus"][i]
+                result["sigmas"] = samples_pyro["sigmas"][i]
 
-        # NOTE: Pyro doesn't have values for discrete latent states (X's)
-        # so assigning everything to 1 so it doesn't break.
-        # We can use this model to get timing info, not evaluation info.
-        result["X[" + str(N - 1) + "]"] = 1
-        samples.append(result)
-    timing_info = {"compile_time": 0, "inference_time": elapsed_time_sample_numpyro}
-    print("inference time: ", elapsed_time_sample_numpyro)
+            # NOTE: Pyro doesn't have values for discrete latent states (X's)
+            # so assigning everything to 1 so it doesn't break.
+            # We can use this model to get timing info, not evaluation info.
+            result["X[" + str(N - 1) + "]"] = 1
+            samples.append(result)
+        timing_info = {"compile_time": 0, "inference_time": elapsed_time_sample_numpyro}
+        print("inference time: ", elapsed_time_sample_numpyro)
 
-    return (samples, timing_info)
+        return (samples, timing_info)

--- a/ppls/pyro/logistic_regression.py
+++ b/ppls/pyro/logistic_regression.py
@@ -14,6 +14,8 @@ import pyro.infer
 import pyro.optim
 import torch
 
+from ..pplbench_ppl import PPLBenchPPL
+
 
 def logistic_model(x_train, y_train=None):
     K = x_train.shape[1]
@@ -27,79 +29,82 @@ def logistic_model(x_train, y_train=None):
     return pyro.sample("y", dist.Bernoulli(logits=mu), obs=y_train)
 
 
-def obtain_posterior(data_train, args_dict, model=None):
-    """
-    Pyro implementation of logistic regression model.
+class LogisticRegression(PPLBenchPPL):
+    def obtain_posterior(self, data_train, args_dict, model=None):
+        """
+        Pyro implementation of logistic regression model.
 
-    Inputs:
-    - data_train(tuple of np.ndarray): x_train, y_train
-    - args_dict: a dict of model arguments
-    Returns:
-    - samples_jags(dict): posterior samples of all parameters
-    - timing_info(dict): compile_time, inference_time
-    """
-    assert pyro.__version__.startswith("0.4.1")
-    global model_args
-    model_args = args_dict["model_args"]
-    LEARNING_RATE = 0.009
-    NUM_STEPS = 3000
-    losses = []
+        Inputs:
+        - data_train(tuple of np.ndarray): x_train, y_train
+        - args_dict: a dict of model arguments
+        Returns:
+        - samples_jags(dict): posterior samples of all parameters
+        - timing_info(dict): compile_time, inference_time
+        """
+        assert pyro.__version__.startswith("0.4.1")
+        global model_args
+        model_args = args_dict["model_args"]
+        LEARNING_RATE = 0.009
+        NUM_STEPS = 3000
+        losses = []
 
-    # x_train is (num_features, num_observations)
-    x_train, y_train = data_train
-    # x_train is (num_observations, num_features)
-    x_train = x_train.T
-    # convert them to tensors
-    x_train = torch.tensor(x_train, dtype=torch.float32)
-    y_train = torch.tensor(y_train, dtype=torch.float32)
+        # x_train is (num_features, num_observations)
+        x_train, y_train = data_train
+        # x_train is (num_observations, num_features)
+        x_train = x_train.T
+        # convert them to tensors
+        x_train = torch.tensor(x_train, dtype=torch.float32)
+        y_train = torch.tensor(y_train, dtype=torch.float32)
 
-    start_time = time.time()
-    # the guide serves as an approximation to the posterior
-    guide = autoguide.AutoDiagonalNormal(logistic_model)
-    optimiser = pyro.optim.Adam({"lr": LEARNING_RATE})
-    loss = pyro.infer.JitTrace_ELBO(vectorize_particles=True)
+        start_time = time.time()
+        # the guide serves as an approximation to the posterior
+        guide = autoguide.AutoDiagonalNormal(logistic_model)
+        optimiser = pyro.optim.Adam({"lr": LEARNING_RATE})
+        loss = pyro.infer.JitTrace_ELBO(vectorize_particles=True)
 
-    # set up the inference algorithm
-    svi = pyro.infer.SVI(
-        logistic_model,
-        guide,
-        optimiser,
-        loss,
-        num_samples=args_dict["num_samples_pyro"],
-    )
-    pyro.clear_param_store()
+        # set up the inference algorithm
+        svi = pyro.infer.SVI(
+            logistic_model,
+            guide,
+            optimiser,
+            loss,
+            num_samples=args_dict["num_samples_pyro"],
+        )
+        pyro.clear_param_store()
 
-    # do the gradient steps
-    for _step in range(NUM_STEPS):
-        loss = svi.step(x_train, y_train)
-        losses.append(loss)
+        # do the gradient steps
+        for _step in range(NUM_STEPS):
+            loss = svi.step(x_train, y_train)
+            losses.append(loss)
 
-    elapsed_time_sample_pyro = time.time() - start_time
+        elapsed_time_sample_pyro = time.time() - start_time
 
-    # plot the ELBO loss to test for convergence
+        # plot the ELBO loss to test for convergence
 
-    plt.plot([i for i in range(NUM_STEPS)], losses)
-    plt.title(
-        "ELBO Loss \n Steps: {} | Learning Rate: {}".format(NUM_STEPS, LEARNING_RATE)
-    )
-    plt.xlabel("Step")
-    plt.ylabel("ELBO Loss")
-    plt.savefig(os.path.join(args_dict["output_dir"], "pyro_elbo_loss.png"))
-    plt.clf()
+        plt.plot(list(range(NUM_STEPS)), losses)
+        plt.title(
+            "ELBO Loss \n Steps: {} | Learning Rate: {}".format(
+                NUM_STEPS, LEARNING_RATE
+            )
+        )
+        plt.xlabel("Step")
+        plt.ylabel("ELBO Loss")
+        plt.savefig(os.path.join(args_dict["output_dir"], "pyro_elbo_loss.png"))
+        plt.clf()
 
-    # repackage samples into shape required by PPLBench
-    samples = []
-    posterior = svi.run(x_train, y_train)
+        # repackage samples into shape required by PPLBench
+        samples = []
+        posterior = svi.run(x_train, y_train)
 
-    # approximate posterior distribution we can get samples from
-    trace = posterior.exec_traces
-    for i in range(args_dict["num_samples_pyro"]):
-        sample_dict = {}
-        sample_dict["alpha"] = trace[i].nodes["alpha"]["value"].detach().numpy()
-        sample_dict["beta"] = trace[i].nodes["beta"]["value"].detach().numpy()
-        samples.append(sample_dict)
-    timing_info = {
-        "compile_time": 0,
-        "inference_time": elapsed_time_sample_pyro,
-    }  # no compiliation for pyro
-    return (samples, timing_info)
+        # approximate posterior distribution we can get samples from
+        trace = posterior.exec_traces
+        for i in range(args_dict["num_samples_pyro"]):
+            sample_dict = {}
+            sample_dict["alpha"] = trace[i].nodes["alpha"]["value"].detach().numpy()
+            sample_dict["beta"] = trace[i].nodes["beta"]["value"].detach().numpy()
+            samples.append(sample_dict)
+        timing_info = {
+            "compile_time": 0,
+            "inference_time": elapsed_time_sample_pyro,
+        }  # no compiliation for pyro
+        return (samples, timing_info)

--- a/ppls/pyro/robust_regression.py
+++ b/ppls/pyro/robust_regression.py
@@ -13,6 +13,8 @@ import torch.nn as nn
 from pyro.infer.mcmc import NUTS
 from pyro.infer.mcmc.api import MCMC
 
+from ..pplbench_ppl import PPLBenchPPL
+
 
 # define a generic regression model
 class RegressionModel(nn.Module):
@@ -52,54 +54,55 @@ def robust_model(x_train, y_train, args_dict):
         pyro.sample("obs", dist.StudentT(df, prediction_mean, sigma), obs=y_train)
 
 
-def obtain_posterior(data_train, args_dict, model=None):
-    """
-    Pyro impmementation of robust regression model.
+class RobustRegression(PPLBenchPPL):
+    def obtain_posterior(self, data_train, args_dict, model=None):
+        """
+        Pyro impmementation of robust regression model.
 
-    Inputs:
-    - data_train(tuple of np.ndarray): x_train, y_train
-    - args_dict: a dict of model arguments
-    Returns:
-    - samples_jags(dict): posterior samples of all parameters
-    - timing_info(dict): compile_time, inference_time
-    """
-    assert pyro.__version__.startswith("0.3.4")
-    x_train, y_train = data_train
-    if args_dict["inference_type"] == "mcmc":
-        start_time = time.time()
-        nuts_kernel = NUTS(model=robust_model, adapt_step_size=True)
-        mcmc = MCMC(
-            nuts_kernel, num_samples=args_dict["num_samples_pyro"], warmup_steps=0
-        )
-        mcmc.run(x_train.T, y_train, args_dict)
-        samples_pyro = mcmc.get_samples()
-    elif args_dict["inference_type"] == "vi":
-        print("ImplementationError; exiting...")
-        exit(1)
+        Inputs:
+        - data_train(tuple of np.ndarray): x_train, y_train
+        - args_dict: a dict of model arguments
+        Returns:
+        - samples_jags(dict): posterior samples of all parameters
+        - timing_info(dict): compile_time, inference_time
+        """
+        assert pyro.__version__.startswith("0.4.1")
+        x_train, y_train = data_train
+        if args_dict["inference_type"] == "mcmc":
+            start_time = time.time()
+            nuts_kernel = NUTS(model=robust_model, adapt_step_size=True)
+            mcmc = MCMC(
+                nuts_kernel, num_samples=args_dict["num_samples_pyro"], warmup_steps=0
+            )
+            mcmc.run(x_train.T, y_train, args_dict)
+            samples_pyro = mcmc.get_samples()
+        elif args_dict["inference_type"] == "vi":
+            print("ImplementationError; exiting...")
+            exit(1)
 
-    elapsed_time_sample_pyro = time.time() - start_time
-    samples_pyro["beta"] = samples_pyro["module$$$linear.weight"].numpy()
-    samples_pyro["alpha"] = samples_pyro["module$$$linear.bias"].numpy()
-    samples_pyro["nu"] = samples_pyro["nu"].numpy().T
-    samples_pyro["sigma"] = samples_pyro["sigma"].numpy().T
-    del samples_pyro["module$$$linear.weight"]
-    del samples_pyro["module$$$linear.bias"]
+        elapsed_time_sample_pyro = time.time() - start_time
+        samples_pyro["beta"] = samples_pyro["module$$$linear.weight"].numpy()
+        samples_pyro["alpha"] = samples_pyro["module$$$linear.bias"].numpy()
+        samples_pyro["nu"] = samples_pyro["nu"].numpy().T
+        samples_pyro["sigma"] = samples_pyro["sigma"].numpy().T
+        del samples_pyro["module$$$linear.weight"]
+        del samples_pyro["module$$$linear.bias"]
 
-    # repackage samples into shape required by PPLBench
-    samples = []
-    # move axes to facilitate iterating over samples
-    # change [sample, chain, values] to [chain, sample, value]
-    samples_pyro["beta"] = np.moveaxis(samples_pyro["beta"], [0, 1, 2], [1, 0, 2])
-    for parameter in samples_pyro.keys():
-        if samples_pyro[parameter].shape[0] == 1:
-            samples_pyro[parameter] = samples_pyro[parameter].squeeze()
-    for i in range(int(args_dict["num_samples_pyro"])):
-        sample_dict = {}
+        # repackage samples into shape required by PPLBench
+        samples = []
+        # move axes to facilitate iterating over samples
+        # change [sample, chain, values] to [chain, sample, value]
+        samples_pyro["beta"] = np.moveaxis(samples_pyro["beta"], [0, 1, 2], [1, 0, 2])
         for parameter in samples_pyro.keys():
-            sample_dict[parameter] = samples_pyro[parameter][i]
-        samples.append(sample_dict)
-    timing_info = {
-        "compile_time": 0,  # no compiliation for pyro
-        "inference_time": elapsed_time_sample_pyro,
-    }
-    return (samples, timing_info)
+            if samples_pyro[parameter].shape[0] == 1:
+                samples_pyro[parameter] = samples_pyro[parameter].squeeze()
+        for i in range(int(args_dict["num_samples_pyro"])):
+            sample_dict = {}
+            for parameter in samples_pyro.keys():
+                sample_dict[parameter] = samples_pyro[parameter][i]
+            samples.append(sample_dict)
+        timing_info = {
+            "compile_time": 0,  # no compiliation for pyro
+            "inference_time": elapsed_time_sample_pyro,
+        }
+        return (samples, timing_info)

--- a/ppls/stan/crowd_sourced_annotation.py
+++ b/ppls/stan/crowd_sourced_annotation.py
@@ -6,6 +6,8 @@ import time
 
 import pystan
 
+from ..pplbench_ppl import PPLBenchPPL
+
 
 CODE = """
 data {
@@ -69,76 +71,81 @@ model {
 """
 
 
-def obtain_posterior(data_train, args_dict, model=None):
-    """
-    Stan implementation of crowdsourced annotation model
+class CrowdSourcedAnnotation(PPLBenchPPL):
+    def obtain_posterior(self, data_train, args_dict, model=None):
+        """
+        Stan implementation of crowdsourced annotation model
 
-    Inputs:
-    - data_train(tuple of np.ndarray): vector_y, vector_J_i, num_labels
-    - args_dict: a dict of model arguments
-    Returns:
-    - samples_stan(dict): posterior samples of all parameters
-    - timing_info(dict): compile_time, inference_time
-    """
-    global CODE
-    vector_y, vector_J_i, num_labels = data_train
-    n_labelers = int(args_dict["k"])
-    n_items = len(num_labels)
-    n_categories, _, expected_correctness, concentration = args_dict["model_args"]
+        Inputs:
+        - data_train(tuple of np.ndarray): vector_y, vector_J_i, num_labels
+        - args_dict: a dict of model arguments
+        Returns:
+        - samples_stan(dict): posterior samples of all parameters
+        - timing_info(dict): compile_time, inference_time
+        """
+        global CODE
+        vector_y, vector_J_i, num_labels = data_train
+        n_labelers = int(args_dict["k"])
+        n_items = len(num_labels)
+        n_categories, _, expected_correctness, concentration = args_dict["model_args"]
 
-    data_stan = {
-        "n_obs": len(vector_y),
-        "n_items": n_items,
-        "n_labelers": n_labelers,
-        "n_categories": n_categories,
-        "expected_correctness": expected_correctness,
-        "concentration": concentration,
-        "n_labels": num_labels,
-        "labels": [i + 1 for i in vector_y],
-        "labeler": [i + 1 for i in vector_J_i],
-    }  # Stan uses 1 indexing
+        data_stan = {
+            "n_obs": len(vector_y),
+            "n_items": n_items,
+            "n_labelers": n_labelers,
+            "n_categories": n_categories,
+            "expected_correctness": expected_correctness,
+            "concentration": concentration,
+            "n_labels": num_labels,
+            "labels": [i + 1 for i in vector_y],
+            "labeler": [i + 1 for i in vector_J_i],
+        }  # Stan uses 1 indexing
 
-    code_loaded = None
-    pkl_filename = os.path.join(
-        args_dict["output_dir"], "stan_crowdSourcedAnnotation.pkl"
-    )
-    if os.path.isfile(pkl_filename):
-        model, code_loaded, elapsed_time_compile_stan = pickle.load(
-            open(pkl_filename, "rb")
+        code_loaded = None
+        pkl_filename = os.path.join(
+            args_dict["output_dir"], "stan_crowdSourcedAnnotation.pkl"
         )
-    if code_loaded != CODE:
-        # compile the model, time it
+        if os.path.isfile(pkl_filename):
+            model, code_loaded, elapsed_time_compile_stan = pickle.load(
+                open(pkl_filename, "rb")
+            )
+        if code_loaded != CODE:
+            # compile the model, time it
+            start_time = time.time()
+            model = pystan.StanModel(
+                model_code=CODE, model_name="crowd_sourced_annotation"
+            )
+            elapsed_time_compile_stan = time.time() - start_time
+            # save it to the file 'model.pkl' for later use
+            with open(pkl_filename, "wb") as f:
+                pickle.dump((model, CODE, elapsed_time_compile_stan), f)
+
+        # sample the parameter posteriors, time it
         start_time = time.time()
-        model = pystan.StanModel(model_code=CODE, model_name="crowd_sourced_annotation")
-        elapsed_time_compile_stan = time.time() - start_time
-        # save it to the file 'model.pkl' for later use
-        with open(pkl_filename, "wb") as f:
-            pickle.dump((model, CODE, elapsed_time_compile_stan), f)
-
-    # sample the parameter posteriors, time it
-    start_time = time.time()
-    if args_dict["inference_type"] == "mcmc":
-        fit = model.sampling(
-            data=data_stan, iter=int(args_dict["num_samples_stan"]), chains=1
+        if args_dict["inference_type"] == "mcmc":
+            fit = model.sampling(
+                data=data_stan, iter=int(args_dict["num_samples_stan"]), chains=1
+            )
+        elif args_dict["inference_type"] == "vi":
+            fit = model.vb(data=data_stan, iter=args_dict["num_samples_stan"])
+        samples_stan = fit.extract(
+            pars=["theta", "pi"], permuted=False, inc_warmup=True
         )
-    elif args_dict["inference_type"] == "vi":
-        fit = model.vb(data=data_stan, iter=args_dict["num_samples_stan"])
-    samples_stan = fit.extract(pars=["theta", "pi"], permuted=False, inc_warmup=True)
-    elapsed_time_sample_stan = time.time() - start_time
+        elapsed_time_sample_stan = time.time() - start_time
 
-    # repackage samples into shape required by PPLBench
-    samples = []
-    for i in range(int(args_dict["num_samples_stan"])):
-        sample_dict = {}
-        for parameter in samples_stan.keys():
-            sample_dict[parameter] = samples_stan[parameter][i]
-            # theta samples have shape (1, J, K, K), need to squeeze the 1 out
-            if sample_dict[parameter].shape[0] == 1:
-                sample_dict[parameter] = sample_dict[parameter].squeeze()
-        samples.append(sample_dict)
-    timing_info = {
-        "compile_time": elapsed_time_compile_stan,
-        "inference_time": elapsed_time_sample_stan,
-    }
+        # repackage samples into shape required by PPLBench
+        samples = []
+        for i in range(int(args_dict["num_samples_stan"])):
+            sample_dict = {}
+            for parameter in samples_stan.keys():
+                sample_dict[parameter] = samples_stan[parameter][i]
+                # theta samples have shape (1, J, K, K), need to squeeze the 1 out
+                if sample_dict[parameter].shape[0] == 1:
+                    sample_dict[parameter] = sample_dict[parameter].squeeze()
+            samples.append(sample_dict)
+        timing_info = {
+            "compile_time": elapsed_time_compile_stan,
+            "inference_time": elapsed_time_sample_stan,
+        }
 
-    return (samples, timing_info)
+        return (samples, timing_info)

--- a/ppls/stan/logistic_regression.py
+++ b/ppls/stan/logistic_regression.py
@@ -7,6 +7,8 @@ import time
 import numpy as np
 import pystan
 
+from ..pplbench_ppl import PPLBenchPPL
+
 
 CODE = """
 data {
@@ -44,81 +46,84 @@ model {
 """
 
 
-def obtain_posterior(data_train, args_dict, model=None):
-    """
-    Stan impmementation of robust regression model.
+class LogisticRegression(PPLBenchPPL):
+    def obtain_posterior(self, data_train, args_dict, model=None):
+        """
+        Stan impmementation of robust regression model.
 
-    Inputs:
-    - data_train(tuple of np.ndarray): x_train, y_train
-    - args_dict: a dict of model arguments
-    Returns:
-    - samples_stan(dict): posterior samples of all parameters
-    - timing_info(dict): compile_time, inference_time
-    """
-    global CODE
-    x_train, y_train = data_train
-    N = int(x_train.shape[1])
-    K = int(x_train.shape[0])
-    alpha_scale, beta_scale, beta_loc, _ = args_dict["model_args"]
+        Inputs:
+        - data_train(tuple of np.ndarray): x_train, y_train
+        - args_dict: a dict of model arguments
+        Returns:
+        - samples_stan(dict): posterior samples of all parameters
+        - timing_info(dict): compile_time, inference_time
+        """
+        global CODE
+        x_train, y_train = data_train
+        N = int(x_train.shape[1])
+        K = int(x_train.shape[0])
+        alpha_scale, beta_scale, beta_loc, _ = args_dict["model_args"]
 
-    data_stan = {
-        "N": N,
-        "K": K,
-        "X": x_train.T,
-        "y": y_train,
-        "scale_alpha": alpha_scale,
-        "scale_beta": beta_scale * np.ones(K),
-        "beta_loc": beta_loc * np.ones(K),
-    }
+        data_stan = {
+            "N": N,
+            "K": K,
+            "X": x_train.T,
+            "y": y_train,
+            "scale_alpha": alpha_scale,
+            "scale_beta": beta_scale * np.ones(K),
+            "beta_loc": beta_loc * np.ones(K),
+        }
 
-    code_loaded = None
-    pkl_filename = os.path.join(args_dict["output_dir"], "stan_logisticRegression.pkl")
-    if os.path.isfile(pkl_filename):
-        model, code_loaded, elapsed_time_compile_stan = pickle.load(
-            open(pkl_filename, "rb")
+        code_loaded = None
+        pkl_filename = os.path.join(
+            args_dict["output_dir"], "stan_logisticRegression.pkl"
         )
-    if code_loaded != CODE:
-        # compile the model, time it
-        start_time = time.time()
-        model = pystan.StanModel(model_code=CODE, model_name="logistic_regression")
-        elapsed_time_compile_stan = time.time() - start_time
-        # save it to the file 'model.pkl' for later use
-        with open(pkl_filename, "wb") as f:
-            pickle.dump((model, CODE, elapsed_time_compile_stan), f)
+        if os.path.isfile(pkl_filename):
+            model, code_loaded, elapsed_time_compile_stan = pickle.load(
+                open(pkl_filename, "rb")
+            )
+        if code_loaded != CODE:
+            # compile the model, time it
+            start_time = time.time()
+            model = pystan.StanModel(model_code=CODE, model_name="logistic_regression")
+            elapsed_time_compile_stan = time.time() - start_time
+            # save it to the file 'model.pkl' for later use
+            with open(pkl_filename, "wb") as f:
+                pickle.dump((model, CODE, elapsed_time_compile_stan), f)
 
-    if args_dict["inference_type"] == "mcmc":
-        # sample the parameter posteriors, time it
-        start_time = time.time()
-        fit = model.sampling(
-            data=data_stan,
-            iter=int(args_dict["num_samples_stan"]),
-            chains=1,
-            check_hmc_diagnostics=False,
-        )
-        samples_stan = fit.extract(
-            pars=["alpha", "beta"], permuted=False, inc_warmup=True
-        )
-        elapsed_time_sample_stan = time.time() - start_time
+        if args_dict["inference_type"] == "mcmc":
+            # sample the parameter posteriors, time it
+            start_time = time.time()
+            fit = model.sampling(
+                data=data_stan,
+                iter=int(args_dict["num_samples_stan"]),
+                chains=1,
+                check_hmc_diagnostics=False,
+            )
+            samples_stan = fit.extract(
+                pars=["alpha", "beta"], permuted=False, inc_warmup=True
+            )
+            elapsed_time_sample_stan = time.time() - start_time
 
-    elif args_dict["inference_type"] == "vi":
-        # sample the parameter posteriors, time it
-        start_time = time.time()
-        fit = model.vb(data=data_stan, iter=args_dict["num_samples_stan"])
-        samples_stan = fit.extract(
-            pars=["alpha", "beta"], permuted=False, inc_warmup=True
-        )
-        elapsed_time_sample_stan = time.time() - start_time
+        elif args_dict["inference_type"] == "vi":
+            # sample the parameter posteriors, time it
+            start_time = time.time()
+            fit = model.vb(data=data_stan, iter=args_dict["num_samples_stan"])
+            samples_stan = fit.extract(
+                pars=["alpha", "beta"], permuted=False, inc_warmup=True
+            )
+            elapsed_time_sample_stan = time.time() - start_time
 
-    # repackage samples into shape required by PPLBench
-    samples = []
-    for i in range(int(args_dict["num_samples_stan"])):
-        sample_dict = {}
-        for parameter in samples_stan.keys():
-            sample_dict[parameter] = samples_stan[parameter][i]
-        samples.append(sample_dict)
-    timing_info = {
-        "compile_time": elapsed_time_compile_stan,
-        "inference_time": elapsed_time_sample_stan,
-    }
+        # repackage samples into shape required by PPLBench
+        samples = []
+        for i in range(int(args_dict["num_samples_stan"])):
+            sample_dict = {}
+            for parameter in samples_stan.keys():
+                sample_dict[parameter] = samples_stan[parameter][i]
+            samples.append(sample_dict)
+        timing_info = {
+            "compile_time": elapsed_time_compile_stan,
+            "inference_time": elapsed_time_sample_stan,
+        }
 
-    return (samples, timing_info)
+        return (samples, timing_info)

--- a/ppls/stan/n_schools.py
+++ b/ppls/stan/n_schools.py
@@ -5,6 +5,8 @@ import time
 import numpy as np
 import pystan
 
+from ..pplbench_ppl import PPLBenchPPL
+
 
 CODE = """
 data {
@@ -70,157 +72,154 @@ model {
 """
 
 
-# define factorize
-def _factorize(random_effect, data):
-    combined = (
-        data[random_effect]
-        .apply(lambda row: "____".join(row.values.astype(str)), axis=1)
-        .values
-    )
-    lvl2num = {}
-    i = 1
-    for val in combined:
-        if val not in lvl2num:
-            lvl2num[val] = i
-            i += 1
-    num2lvl = {i: v for v, i in lvl2num.items()}
-    random_effect_level_map = {"num2lvl": num2lvl, "lvl2num": lvl2num}
-    return random_effect_level_map
+class NSchools(PPLBenchPPL):
+    # define factorize
+    def _factorize(self, random_effect, data):
+        combined = (
+            data[random_effect]
+            .apply(lambda row: "____".join(row.values.astype(str)), axis=1)
+            .values
+        )
+        lvl2num = {}
+        i = 1
+        for val in combined:
+            if val not in lvl2num:
+                lvl2num[val] = i
+                i += 1
+        num2lvl = {i: v for v, i in lvl2num.items()}
+        random_effect_level_map = {"num2lvl": num2lvl, "lvl2num": lvl2num}
+        return random_effect_level_map
 
-
-# get _get_n_levels
-def _get_n_levels(data):
-    ns = np.array([], dtype=int)
-    for random_effect in [["state", "district"], ["type"]]:
-        for i in range(len(random_effect), 0, -1):
-            curr_lvls = random_effect[:i]
-            lvl_map = _factorize(curr_lvls, data)
-            lvl2num = lvl_map["lvl2num"]
-            ns = np.append(ns, len(lvl2num))
-    return ns
-
-
-# define mapping
-def _get_mapping(data):
-    mapping = np.empty((0, data.shape[0]), dtype=int)
-    for random_effect in [["state", "district"], ["type"]]:
-        for i in range(len(random_effect), 0, -1):
-            curr_lvls = random_effect[:i]
-            lvl_map = _factorize(curr_lvls, data)
-            lvl2num = lvl_map["lvl2num"]
-            combined = (
-                data[curr_lvls]
-                .apply(lambda row: "____".join(row.values.astype(str)), axis=1)
-                .values
-            )
-            curr_map = np.array([lvl2num[x] for x in combined])
-            mapping = np.append(mapping, [curr_map], axis=0)
-
-    return mapping.T
-
-
-# define ranges
-def _get_ranges(data):
-    n_levels = _get_n_levels(data)
-    cumsum_ns = np.cumsum(n_levels, dtype=int)
-    tmp = np.concatenate((cumsum_ns, np.array([0], dtype=int)))
-    start = np.concatenate(
-        (np.array([1], dtype=int), 1 + cumsum_ns[:-1], np.array([0], dtype=int))
-    )
-    ranges = np.array((start, tmp)).T
-    return ranges
-
-
-def obtain_posterior(data_train, args_dict, model=None):
-    """
-    Stan impmementation of n-school model.
-
-    Inputs:
-    - data_train
-    - args_dict: a dict of model arguments
-    Returns:
-    - samples_stan(dict): posterior samples of all parameters
-    - timing_info(dict): compile_time, inference_time
-    """
-    global CODE
-
-    # mapping
-    mapping = _get_mapping(data_train)
-
-    # ranges
-    ranges = _get_ranges(data_train)
-
-    # n_levels
-    n_levels = _get_n_levels(data_train)
-
-    # define sum_ns
-    sum_ns = np.sum(n_levels)
-
-    # generating stan mapping to state/district/type values!
-    re_map_to_stan_params = {}
-    for i in range(data_train.shape[0]):
-        re_q_position = 0
+    # get _get_n_levels
+    def _get_n_levels(self, data):
+        ns = np.array([], dtype=int)
         for random_effect in [["state", "district"], ["type"]]:
-            for j in range(len(random_effect), 0, -1):
-                curr_lvls = random_effect[:j]
-                combined = "beta_" + "_".join(
-                    [lvl + "_" + str(data_train[lvl].iloc[i]) for lvl in curr_lvls]
+            for i in range(len(random_effect), 0, -1):
+                curr_lvls = random_effect[:i]
+                lvl_map = self._factorize(curr_lvls, data)
+                lvl2num = lvl_map["lvl2num"]
+                ns = np.append(ns, len(lvl2num))
+        return ns
+
+    # define mapping
+    def _get_mapping(self, data):
+        mapping = np.empty((0, data.shape[0]), dtype=int)
+        for random_effect in [["state", "district"], ["type"]]:
+            for i in range(len(random_effect), 0, -1):
+                curr_lvls = random_effect[:i]
+                lvl_map = self._factorize(curr_lvls, data)
+                lvl2num = lvl_map["lvl2num"]
+                combined = (
+                    data[curr_lvls]
+                    .apply(lambda row: "____".join(row.values.astype(str)), axis=1)
+                    .values
                 )
-                if combined not in re_map_to_stan_params:
-                    re_map_to_stan_params[combined] = (ranges[re_q_position][0]) + (
-                        mapping[i][re_q_position] - 1
+                curr_map = np.array([lvl2num[x] for x in combined])
+                mapping = np.append(mapping, [curr_map], axis=0)
+
+        return mapping.T
+
+    # define ranges
+    def _get_ranges(self, data):
+        n_levels = self._get_n_levels(data)
+        cumsum_ns = np.cumsum(n_levels, dtype=int)
+        tmp = np.concatenate((cumsum_ns, np.array([0], dtype=int)))
+        start = np.concatenate(
+            (np.array([1], dtype=int), 1 + cumsum_ns[:-1], np.array([0], dtype=int))
+        )
+        ranges = np.array((start, tmp)).T
+        return ranges
+
+    def obtain_posterior(self, data_train, args_dict, model=None):
+        """
+      Stan impmementation of n-school model.
+
+      Inputs:
+      - data_train
+      - args_dict: a dict of model arguments
+      Returns:
+      - samples_stan(dict): posterior samples of all parameters
+      - timing_info(dict): compile_time, inference_time
+      """
+        global CODE
+
+        # mapping
+        mapping = self._get_mapping(data_train)
+
+        # ranges
+        ranges = self._get_ranges(data_train)
+
+        # n_levels
+        n_levels = self._get_n_levels(data_train)
+
+        # define sum_ns
+        sum_ns = np.sum(n_levels)
+
+        # generating stan mapping to state/district/type values!
+        re_map_to_stan_params = {}
+        for i in range(data_train.shape[0]):
+            re_q_position = 0
+            for random_effect in [["state", "district"], ["type"]]:
+                for j in range(len(random_effect), 0, -1):
+                    curr_lvls = random_effect[:j]
+                    combined = "beta_" + "_".join(
+                        [lvl + "_" + str(data_train[lvl].iloc[i]) for lvl in curr_lvls]
                     )
-                re_q_position += 1
+                    if combined not in re_map_to_stan_params:
+                        re_map_to_stan_params[combined] = (ranges[re_q_position][0]) + (
+                            mapping[i][re_q_position] - 1
+                        )
+                    re_q_position += 1
 
-    data_stan = {
-        "n": data_train.shape[0],
-        "p": 1,
-        "q": 3,
-        "yi": data_train["yi"].values,
-        "sei": data_train["sei"].values,
-        "X": np.ones(shape=data_train.shape[0])[..., None],
-        "ranges": ranges,
-        "sum_ns": sum_ns,
-        "mapping": mapping,
-        "sd_tau": 1.0,
-    }
-
-    # compile the model, time it
-    start_time = time.time()
-    model = pystan.StanModel(model_code=CODE, model_name="n_schools")
-    elapsed_time_compile_stan = time.time() - start_time
-
-    if args_dict["inference_type"] == "vi":
-        raise Exception(f"VI is not supported for the N_schools model.")
-
-    elif args_dict["inference_type"] == "mcmc":
-        # sample the parameter posteriors, time it
-        start_time = time.time()
-        fit = model.sampling(
-            data=data_stan,
-            iter=int(args_dict["num_samples_stan"]),
-            chains=1,
-            check_hmc_diagnostics=False,
-        )
-        samples_stan = fit.to_dataframe(
-            pars=["beta_c", "sds", "u"],
-            permuted=False,
-            inc_warmup=True,
-            diagnostics=False,
-        )
-        elapsed_time_sample_stan = time.time() - start_time
-
-        # rename columns to be similar to BMG n_school
-        samples_stan.rename(
-            columns={f"u[{v}]": k for k, v in re_map_to_stan_params.items()},
-            inplace=True,
-        )
-
-        samples_stan.rename(columns={"beta_c[1]": "beta_0"}, inplace=True)
-
-        timing_info = {
-            "compile_time": elapsed_time_compile_stan,
-            "inference_time": elapsed_time_sample_stan,
+        data_stan = {
+            "n": data_train.shape[0],
+            "p": 1,
+            "q": 3,
+            "yi": data_train["yi"].values,
+            "sei": [i.item() for i in data_train["sei"].values],
+            "X": np.ones(shape=data_train.shape[0])[..., None],
+            "ranges": ranges,
+            "sum_ns": sum_ns,
+            "mapping": mapping,
+            "sd_tau": 1.0,
         }
 
-        return (samples_stan, timing_info)
+        # compile the model, time it
+        start_time = time.time()
+        model = pystan.StanModel(model_code=CODE, model_name="n_schools")
+        elapsed_time_compile_stan = time.time() - start_time
+
+        if args_dict["inference_type"] == "vi":
+            raise Exception(f"VI is not supported for the N_schools model.")
+
+        elif args_dict["inference_type"] == "mcmc":
+            # sample the parameter posteriors, time it
+            start_time = time.time()
+            fit = model.sampling(
+                data=data_stan,
+                iter=int(args_dict["num_samples_stan"]),
+                chains=1,
+                check_hmc_diagnostics=False,
+            )
+            samples_stan = fit.to_dataframe(
+                pars=["beta_c", "sds", "u"],
+                permuted=False,
+                inc_warmup=True,
+                diagnostics=False,
+            )
+            elapsed_time_sample_stan = time.time() - start_time
+
+            # rename columns to be similar to BMG n_school
+            samples_stan.rename(
+                columns={f"u[{v}]": k for k, v in re_map_to_stan_params.items()},
+                inplace=True,
+            )
+
+            samples_stan.rename(columns={"beta_c[1]": "beta_0"}, inplace=True)
+
+            timing_info = {
+                "compile_time": elapsed_time_compile_stan,
+                "inference_time": elapsed_time_sample_stan,
+            }
+
+            return (samples_stan, timing_info)

--- a/ppls/stan/noisy_or_topic.py
+++ b/ppls/stan/noisy_or_topic.py
@@ -7,147 +7,150 @@ import time
 import numpy as np
 import pystan
 
+from ..pplbench_ppl import PPLBenchPPL
 
-def obtain_posterior(data_train, args_dict, model):
-    """
-    Stan impmementation of Noisy-Or Topic Model.
 
-    Inputs:
-    - data_train(tuple of np.ndarray): graph, words
-    - args_dict: a dict of model arguments
-    - model: the model object
-    Returns:
-    - samples_stan(dict): posterior samples of all parameters
-    - timing_info(dict): compile_time, inference_time
-    """
-    graph = model
-    words = data_train
-    K = int(args_dict["k"])
-    word_fraction = (args_dict["model_args"])[3]
-    T = int(K * (1 - word_fraction))
-    assert len(words.shape) == 1
-    # construct the Stan code for the graph
-    tokens = graph[T:]
-    topics = graph[:T]
-    code = """
-data {{
-    int num_tokens;
-    int tokens[num_tokens];
-    real tau;
-}}
-
-transformed data {{
-    int NUM_TOKENS = {};  // this better match num_tokens in input!
-    int NUM_TOPICS = {};
-}}
-
-parameters {{
-    // these two gumbel parameters control the sampling probability
-    // for each node in the graph
-    vector[2] gumbel_topics[NUM_TOPICS];
-}}
-
-transformed parameters {{
-    vector[NUM_TOKENS] token_prob;
-    vector[NUM_TOPICS] topic_prob;
-
-    matrix[NUM_TOPICS, 2] topic;  // the state of each topic [True, False]
-
-    """.format(
-        len(tokens), len(topics) - 1
-    )
-    for node in range(1, T):
-        code += """
-    topic_prob[{}] = 1 - exp(""".format(
-            node
-        )
-        for par, wt in enumerate(graph[:, node]):
-            if par == 0:
-                code += "-{}".format(wt)
-            elif wt:
-                code += "- topic[{}] * [{}, 0]'".format(par, wt)
-        code += """);
-    topic[{}] = softmax((log([topic_prob[{}], 1-topic_prob[{}]]')
-        + gumbel_topics[{}])/tau)';
-        """.format(
-            node, node, node, node
-        )
-    # add the token probabilities
-    for node in range(T, K):
-        code += """
-    token_prob[{}] = 1 - exp(""".format(
-            node + 1 - T
-        )
-        for par, wt in enumerate(graph[:, node]):
-            if par == 0:
-                code += "-{}".format(wt)
-            elif wt:
-                code += "- topic[{}] * [{}, 0]'".format(par, wt)
-        code += """);
+class NoisyOrTopic(PPLBenchPPL):
+    def obtain_posterior(self, data_train, args_dict, model):
         """
-    # add the rest of the model
-    code += """
-}
+        Stan impmementation of Noisy-Or Topic Model.
 
-model {
-    for  (n in 1:NUM_TOPICS) {
-        gumbel_topics[n] ~ gumbel(0, 1);
-    }
-    tokens ~ bernoulli(token_prob);
-}
-"""
-    data_stan = {
-        "num_tokens": len(tokens),
-        "tau": 0.1,
-        "tokens": np.array(words, dtype=int),
-    }
-    code_loaded = None
-    if os.path.isfile("./ppls/stan/noisyOrTopic.pkl"):
-        model, code_loaded, elapsed_time_compile_stan = pickle.load(
-            open("./ppls/stan/noisyOrTopic.pkl", "rb")
-        )
-    if code_loaded != code:
-        # compile the model, time it
-        start_time = time.time()
-        model = pystan.StanModel(model_code=code, model_name="noisy_or_topic")
-        elapsed_time_compile_stan = time.time() - start_time
-        # save it to the file 'model.pkl' for later use
-        with open("./ppls/stan/noisyOrTopic.pkl", "wb") as f:
-            pickle.dump((model, code, elapsed_time_compile_stan), f)
+        Inputs:
+        - data_train(tuple of np.ndarray): graph, words
+        - args_dict: a dict of model arguments
+        - model: the model object
+        Returns:
+        - samples_stan(dict): posterior samples of all parameters
+        - timing_info(dict): compile_time, inference_time
+        """
+        graph = model
+        words = data_train
+        K = int(args_dict["k"])
+        word_fraction = (args_dict["model_args"])[3]
+        T = int(K * (1 - word_fraction))
+        assert len(words.shape) == 1
+        # construct the Stan code for the graph
+        tokens = graph[T:]
+        topics = graph[:T]
+        code = """
+    data {{
+        int num_tokens;
+        int tokens[num_tokens];
+        real tau;
+    }}
 
-    if args_dict["inference_type"] == "mcmc":
-        # sample the parameter posteriors, time it
-        start_time = time.time()
-        fit = model.sampling(
-            data=data_stan,
-            iter=int(args_dict["num_samples_stan"]),
-            chains=1,
-            check_hmc_diagnostics=False,
-        )
-        samples_stan = fit.extract(pars=["topic"], permuted=False, inc_warmup=True)
-        elapsed_time_sample_stan = time.time() - start_time
+    transformed data {{
+        int NUM_TOKENS = {};  // this better match num_tokens in input!
+        int NUM_TOPICS = {};
+    }}
 
-    elif args_dict["inference_type"] == "vi":
-        # sample the parameter posteriors, time it
-        start_time = time.time()
-        fit = model.vb(
-            data=data_stan, iter=args_dict["num_samples_stan"], pars=["topic"]
+    parameters {{
+        // these two gumbel parameters control the sampling probability
+        // for each node in the graph
+        vector[2] gumbel_topics[NUM_TOPICS];
+    }}
+
+    transformed parameters {{
+        vector[NUM_TOKENS] token_prob;
+        vector[NUM_TOPICS] topic_prob;
+
+        matrix[NUM_TOPICS, 2] topic;  // the state of each topic [True, False]
+
+        """.format(
+            len(tokens), len(topics) - 1
         )
-        samples_stan = fit.extract(pars=["topic"], permuted=False, inc_warmup=True)
-        elapsed_time_sample_stan = time.time() - start_time
-    # convert shape of samples from prob(1), prob(0) to 1s and 0s
-    samples_stan["topic"] = 1 - samples_stan["topic"].argmax(axis=3)
-    # append the leak node as 1 in each sample as it is not sampled in the model
-    samples_stan["topic"] = np.insert(samples_stan["topic"], 0, 1, axis=2)
-    # repackage samples into shape required by PPLBench
-    samples = []
-    for i in range(int(args_dict["num_samples_stan"])):
-        sample_dict = {}
-        for parameter in samples_stan.keys():
-            sample_dict["node"] = samples_stan[parameter][i].reshape(-1)
-        samples.append(sample_dict)
-    timing_info = {
-        "compile_time": elapsed_time_compile_stan,
-        "inference_time": elapsed_time_sample_stan,
+        for node in range(1, T):
+            code += """
+        topic_prob[{}] = 1 - exp(""".format(
+                node
+            )
+            for par, wt in enumerate(graph[:, node]):
+                if par == 0:
+                    code += "-{}".format(wt)
+                elif wt:
+                    code += "- topic[{}] * [{}, 0]'".format(par, wt)
+            code += """);
+        topic[{}] = softmax((log([topic_prob[{}], 1-topic_prob[{}]]')
+            + gumbel_topics[{}])/tau)';
+            """.format(
+                node, node, node, node
+            )
+        # add the token probabilities
+        for node in range(T, K):
+            code += """
+        token_prob[{}] = 1 - exp(""".format(
+                node + 1 - T
+            )
+            for par, wt in enumerate(graph[:, node]):
+                if par == 0:
+                    code += "-{}".format(wt)
+                elif wt:
+                    code += "- topic[{}] * [{}, 0]'".format(par, wt)
+            code += """);
+            """
+        # add the rest of the model
+        code += """
     }
-    return (samples, timing_info)
+
+    model {
+        for  (n in 1:NUM_TOPICS) {
+            gumbel_topics[n] ~ gumbel(0, 1);
+        }
+        tokens ~ bernoulli(token_prob);
+    }
+    """
+        data_stan = {
+            "num_tokens": len(tokens),
+            "tau": 0.1,
+            "tokens": np.array(words, dtype=int),
+        }
+        code_loaded = None
+        if os.path.isfile("./ppls/stan/noisyOrTopic.pkl"):
+            model, code_loaded, elapsed_time_compile_stan = pickle.load(
+                open("./ppls/stan/noisyOrTopic.pkl", "rb")
+            )
+        if code_loaded != code:
+            # compile the model, time it
+            start_time = time.time()
+            model = pystan.StanModel(model_code=code, model_name="noisy_or_topic")
+            elapsed_time_compile_stan = time.time() - start_time
+            # save it to the file 'model.pkl' for later use
+            with open("./ppls/stan/noisyOrTopic.pkl", "wb") as f:
+                pickle.dump((model, code, elapsed_time_compile_stan), f)
+
+        if args_dict["inference_type"] == "mcmc":
+            # sample the parameter posteriors, time it
+            start_time = time.time()
+            fit = model.sampling(
+                data=data_stan,
+                iter=int(args_dict["num_samples_stan"]),
+                chains=1,
+                check_hmc_diagnostics=False,
+            )
+            samples_stan = fit.extract(pars=["topic"], permuted=False, inc_warmup=True)
+            elapsed_time_sample_stan = time.time() - start_time
+
+        elif args_dict["inference_type"] == "vi":
+            # sample the parameter posteriors, time it
+            start_time = time.time()
+            fit = model.vb(
+                data=data_stan, iter=args_dict["num_samples_stan"], pars=["topic"]
+            )
+            samples_stan = fit.extract(pars=["topic"], permuted=False, inc_warmup=True)
+            elapsed_time_sample_stan = time.time() - start_time
+        # convert shape of samples from prob(1), prob(0) to 1s and 0s
+        samples_stan["topic"] = 1 - samples_stan["topic"].argmax(axis=3)
+        # append the leak node as 1 in each sample as it is not sampled in the model
+        samples_stan["topic"] = np.insert(samples_stan["topic"], 0, 1, axis=2)
+        # repackage samples into shape required by PPLBench
+        samples = []
+        for i in range(int(args_dict["num_samples_stan"])):
+            sample_dict = {}
+            for parameter in samples_stan.keys():
+                sample_dict["node"] = samples_stan[parameter][i].reshape(-1)
+            samples.append(sample_dict)
+        timing_info = {
+            "compile_time": elapsed_time_compile_stan,
+            "inference_time": elapsed_time_sample_stan,
+        }
+        return (samples, timing_info)

--- a/ppls/stan/robust_regression.py
+++ b/ppls/stan/robust_regression.py
@@ -6,6 +6,8 @@ import time
 
 import pystan
 
+from ..pplbench_ppl import PPLBenchPPL
+
 
 CODE = """
 // Linear Model with Student-t Errors
@@ -52,82 +54,85 @@ model {
 """
 
 
-def obtain_posterior(data_train, args_dict, model=None):
-    """
-    Stan impmementation of robust regression model.
+class RobustRegression(PPLBenchPPL):
+    def obtain_posterior(self, data_train, args_dict, model=None):
+        """
+        Stan impmementation of robust regression model.
 
-    Inputs:
-    - data_train(tuple of np.ndarray): x_train, y_train
-    - args_dict: a dict of model arguments
-    Returns:
-    - samples_stan(dict): posterior samples of all parameters
-    - timing_info(dict): compile_time, inference_time
-    """
-    global CODE
-    x_train, y_train = data_train
-    N = int(x_train.shape[1])
-    K = int(x_train.shape[0])
-    alpha_scale, beta_scale, beta_loc, sigma_mean = args_dict["model_args"]
+        Inputs:
+        - data_train(tuple of np.ndarray): x_train, y_train
+        - args_dict: a dict of model arguments
+        Returns:
+        - samples_stan(dict): posterior samples of all parameters
+        - timing_info(dict): compile_time, inference_time
+        """
+        global CODE
+        x_train, y_train = data_train
+        N = int(x_train.shape[1])
+        K = int(x_train.shape[0])
+        alpha_scale, beta_scale, beta_loc, sigma_mean = args_dict["model_args"]
 
-    data_stan = {
-        "N": N,
-        "K": K,
-        "X": x_train.T,
-        "y": y_train,
-        "scale_alpha": alpha_scale,
-        "scale_beta": beta_scale,
-        "loc_beta": beta_loc,
-        "rate_sigma": 1.0 / sigma_mean,
-    }
+        data_stan = {
+            "N": N,
+            "K": K,
+            "X": x_train.T,
+            "y": y_train,
+            "scale_alpha": alpha_scale,
+            "scale_beta": beta_scale,
+            "loc_beta": beta_loc,
+            "rate_sigma": 1.0 / sigma_mean,
+        }
 
-    code_loaded = None
-    pkl_filename = os.path.join(args_dict["output_dir"], "stan_robustRegression.pkl")
-    if os.path.isfile(pkl_filename):
-        model, code_loaded, elapsed_time_compile_stan = pickle.load(
-            open(pkl_filename, "rb")
+        code_loaded = None
+        pkl_filename = os.path.join(
+            args_dict["output_dir"], "stan_robustRegression.pkl"
         )
-    if code_loaded != CODE:
-        # compile the model, time it
-        start_time = time.time()
-        model = pystan.StanModel(model_code=CODE, model_name="robust_regression")
-        elapsed_time_compile_stan = time.time() - start_time
-        # save it to the file 'model.pkl' for later use
-        with open(pkl_filename, "wb") as f:
-            pickle.dump((model, CODE, elapsed_time_compile_stan), f)
+        if os.path.isfile(pkl_filename):
+            model, code_loaded, elapsed_time_compile_stan = pickle.load(
+                open(pkl_filename, "rb")
+            )
+        if code_loaded != CODE:
+            # compile the model, time it
+            start_time = time.time()
+            model = pystan.StanModel(model_code=CODE, model_name="robust_regression")
+            elapsed_time_compile_stan = time.time() - start_time
+            # save it to the file 'model.pkl' for later use
+            with open(pkl_filename, "wb") as f:
+                pickle.dump((model, CODE, elapsed_time_compile_stan), f)
 
-    if args_dict["inference_type"] == "mcmc":
-        # sample the parameter posteriors, time it
-        start_time = time.time()
-        fit = model.sampling(
-            data=data_stan,
-            iter=int(args_dict["num_samples_stan"]),
-            chains=1,
-            check_hmc_diagnostics=False,
-        )
-        samples_stan = fit.extract(
-            pars=["alpha", "beta", "sigma", "nu"], permuted=False, inc_warmup=True
-        )
-        elapsed_time_sample_stan = time.time() - start_time
+        if args_dict["inference_type"] == "mcmc":
+            # sample the parameter posteriors, time it
+            start_time = time.time()
+            fit = model.sampling(
+                data=data_stan,
+                iter=int(args_dict["num_samples_stan"]),
+                chains=1,
+                check_hmc_diagnostics=False,
+            )
+            samples_stan = fit.extract(
+                pars=["alpha", "beta", "sigma", "nu"], permuted=False, inc_warmup=True
+            )
+            elapsed_time_sample_stan = time.time() - start_time
 
-    elif args_dict["inference_type"] == "vi":
-        # sample the parameter posteriors, time it
-        start_time = time.time()
-        fit = model.vb(data=data_stan, iter=args_dict["num_samples_stan"])
-        samples_stan = fit.extract(
-            pars=["alpha", "beta", "sigma", "nu"], permuted=False, inc_warmup=True
-        )
-        elapsed_time_sample_stan = time.time() - start_time
+        elif args_dict["inference_type"] == "vi":
+            # sample the parameter posteriors, time it
+            start_time = time.time()
+            fit = model.vb(data=data_stan, iter=args_dict["num_samples_stan"])
+            samples_stan = fit.extract(
+                pars=["alpha", "beta", "sigma", "nu"], permuted=False, inc_warmup=True
+            )
+            elapsed_time_sample_stan = time.time() - start_time
 
-    # repackage samples into shape required by PPLBench
-    samples = []
-    for i in range(int(args_dict["num_samples_stan"])):
-        sample_dict = {}
-        for parameter in samples_stan.keys():
-            sample_dict[parameter] = samples_stan[parameter][i]
-        samples.append(sample_dict)
-    timing_info = {
-        "compile_time": elapsed_time_compile_stan,
-        "inference_time": elapsed_time_sample_stan,
-    }
+        # repackage samples into shape required by PPLBench
+        samples = []
+        for i in range(int(args_dict["num_samples_stan"])):
+            sample_dict = {}
+            for parameter in samples_stan.keys():
+                sample_dict[parameter] = samples_stan[parameter][i]
+            samples.append(sample_dict)
+        timing_info = {
+            "compile_time": elapsed_time_compile_stan,
+            "inference_time": elapsed_time_sample_stan,
+        }
 
-    return (samples, timing_info)
+        return (samples, timing_info)


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookincubator/BeanMachine/pull/119

To enforce the implementation of the ```obtain_posterior ``` function, and to have better code quality in general, all ppl implementations now have to inherit from an abstract PPL class.

Reviewed By: dnoursi

Differential Revision: D20378788

