### PR TITLE
Setting number of adaptive samples in config

### DIFF
--- a/pplbench/ppls/jags/inference.py
+++ b/pplbench/ppls/jags/inference.py
@@ -1,5 +1,5 @@
 # Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
-from typing import Dict, Type, cast
+from typing import Dict, Optional, Type, cast
 
 import pyjags
 import xarray as xr
@@ -28,7 +28,7 @@ class MCMC(BasePPLInference):
         data: xr.Dataset,
         num_samples: int,
         seed: int,
-        adapt: int = 0,
+        adapt: Optional[int] = None,
         RNG_name: str = "base::Mersenne-Twister",
     ) -> xr.Dataset:
         """
@@ -42,6 +42,9 @@ class MCMC(BasePPLInference):
         :param RNG_name: the name of the random number generator
         :returns: samples dataset
         """
+        if adapt is None:
+            adapt = num_samples
+
         model = pyjags.Model(
             code=self.impl.get_code(),
             data=self.impl.format_data_to_jags(data),

--- a/pplbench/ppls/pymc3/inference.py
+++ b/pplbench/ppls/pymc3/inference.py
@@ -1,6 +1,6 @@
 # Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
 
-from typing import Dict, Type, cast
+from typing import Dict, Optional, Type, cast
 
 import pymc3 as pm
 import xarray as xr
@@ -28,9 +28,12 @@ class MCMC(BasePyMC3Inference):
         data: xr.Dataset,
         num_samples: int,
         seed: int,
+        tune: Optional[int] = None,
         algorithm: str = "NUTS",
         **infer_args
     ) -> xr.Dataset:
+        if tune is None:
+            tune = num_samples
 
         model = self.impl.get_model(data)
         with model:
@@ -38,6 +41,7 @@ class MCMC(BasePyMC3Inference):
             step_method = getattr(pm, algorithm)(model.vars, **infer_args)
             samples = pm.sample(
                 draws=num_samples,
+                tune=tune,
                 step=step_method,
                 random_seed=seed,
                 chains=1,

--- a/pplbench/ppls/stan/inference.py
+++ b/pplbench/ppls/stan/inference.py
@@ -1,6 +1,6 @@
 # Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
 from collections import OrderedDict
-from typing import Dict, Type, cast
+from typing import Dict, Optional, Type, cast
 
 import numpy as np
 import xarray as xr
@@ -33,16 +33,21 @@ class MCMC(BaseStanInference):
         data: xr.Dataset,
         num_samples: int,
         seed: int,
+        warmup: Optional[int] = None,
         algorithm: str = "NUTS",
         **infer_args
     ) -> xr.Dataset:
         """
         See https://pystan.readthedocs.io/en/latest/api.html#pystan.StanModel.vb
         """
+        if warmup is None:
+            warmup = num_samples
+
         self.fit = self.stan_model.sampling(
             data=self.impl.format_data_to_stan(data),
             pars=self.impl.get_pars(),
-            iter=num_samples,
+            iter=num_samples + warmup,
+            warmup=warmup,
             chains=1,
             check_hmc_diagnostics=False,
             seed=seed,
@@ -50,7 +55,7 @@ class MCMC(BaseStanInference):
             **infer_args
         )
         results = self.fit.extract(
-            permuted=False, inc_warmup=True, pars=self.impl.get_pars()
+            permuted=False, inc_warmup=False, pars=self.impl.get_pars()
         )
         return self.impl.extract_data_from_stan(results)
 


### PR DESCRIPTION
Summary: As titled. By default, the number of adaptive samples is set to the same as num_samples for all PPLs (in supporting algorithms), though this can be overwritten by passing in other values through infer_args.

Differential Revision: D24342571

