### PR TITLE
Adds an entry point for PPL Bench

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ commands:
           command: >
             circleci tests glob "examples/*.json" |
             circleci tests split |
-            xargs -n 1 -t python -um pplbench.main
+            xargs -n 1 -t python -um pplbench
 
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ PPL Bench is a new benchmark framework for evaluating the performance of probabi
 Let's dive right in with a benchmark run of Bayesian Logistic Regression. Run the following command:
 
 ```
-python -m pplbench.main examples/example.json
+python -m pplbench examples/example.json
 ```
 
 This will create a benchmark run with two trials of Stan on the Bayesian Logistic Regression model. The results of the run are saved in the `pplbench/outputs/` directory.
@@ -45,7 +45,7 @@ This is what the PLL plot should look like:
 Please see the [examples/example.json](examples/example.json) file to understand the schema for specifying benchmark runs. The schema is documented in [pplbench/main.py](pplbench/main.py) and can be printed by running the help command:
 
 ```
-python -m pplbench.main -h
+python -m pplbench -h
 ```
 
 A number of models is available in the `pplbench/models` directory and the PPL implementations are available in the `pplbench/ppls` directory.

--- a/pplbench/__main__.py
+++ b/pplbench/__main__.py
@@ -1,0 +1,24 @@
+# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+import os
+import sys
+
+from .main import main
+
+
+def console_main() -> None:
+    """The entry point for CLI with special handling for BrokenPipError. This function is
+    not intended to be called as a function from another program."""
+    try:
+        main()
+        sys.stdout.flush()
+        sys.stderr.flush()
+    except BrokenPipeError:
+        # Python flushes standard streams on exit; redirect remaining output
+        # to devnull to avoid another BrokenPipeError at shutdown
+        devnull = os.open(os.devnull, os.O_WRONLY)
+        os.dup2(devnull, sys.stdout.fileno())
+        sys.exit(1)  # Python exits with error code 1 on EPIPE
+
+
+if __name__ == "__main__":
+    console_main()

--- a/pplbench/main.py
+++ b/pplbench/main.py
@@ -163,7 +163,3 @@ def configure_logging(config: SimpleNamespace, output_dir: str) -> None:
         ch.setFormatter(formatter)
         logging.getLogger().addHandler(ch)
     LOGGER.debug(f"config - {str(config)}")
-
-
-if __name__ == "__main__":
-    main()

--- a/setup.py
+++ b/setup.py
@@ -74,4 +74,5 @@ setup(
     ],
     packages=find_packages(),
     extras_require={"dev": DEV_REQUIRES},
+    entry_points={"console_scripts": ["pplbench=pplbench.__main__:console_main"]},
 )


### PR DESCRIPTION
Summary:
Instead of invoking PPL Bench from `pplbench.main`, we could run the module directly by creating `__main__.py` at the root of the package. This allows us to directly invoke PPL Bench via `python -m pplbench`.

(The scripts for handling `BrokenPipError` is taken from [Python's official doc](https://docs.python.org/3/library/signal.html#note-on-sigpipe))

I'm also adding an entry point in `setup.py` so that after user install PPL Bench via pip, it could be directly invoke from anywhere as a command line tool, i.e.

```
pplbench <config_file.json>
```

(Note that we might still need to update `setup.py` to make sure we have up to date dependencies before we can use it as a package.)

Differential Revision: D24373080

