### PR TITLE
Bump black linter's version to 20.8b1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ commands:
       - run:
           name: "Install lint packages"
           command: >
-            sudo pip install --progress-bar off black==19.3b0 isort==4.3.21
+            sudo pip install --progress-bar off black==20.8b1 isort==4.3.21
             flake8==3.8.1 mypy==0.782
 
   pip_install_pplbench_core:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ PPLS_REQUIRE = [
     "pyro-ppl>=0.4.1",
     "numpyro>=0.3.0",
 ]
-DEV_REQUIRE = PPLS_REQUIRE + ["black==19.3b0", "isort", "flake8"]
+DEV_REQUIRE = PPLS_REQUIRE + ["black==20.8b1", "isort", "flake8", "mypy"]
 
 
 # Check for python version


### PR DESCRIPTION
Summary: Beanmachine's [CircleCI linter workflow](https://app.circleci.com/pipelines/github/facebookincubator/beanmachine/1582/workflows/0093a28a-227d-44c9-8e43-6f5475964380/jobs/3238) has been failing since the codemod that bump the internal version of black linter to 20.8b1 (D24325133). So I guess it's time to upgrade the black linter's version on CircleCI as well. ;)

Differential Revision: D24431864

