### PR TITLE
Automatically deploy pplbench to PyPI on new tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,24 @@ commands:
             circleci tests split |
             xargs -n 1 -t pplbench
 
+  package_pplbench:
+    steps:
+      - run:
+          name: "Install packaging dependencies"
+          command: sudo pip install --progress-bar off setuptools wheel twine
+      - run:
+          name: "Build source distribution"
+          command: python setup.py sdist
+      - run:
+          name: "Build Python 3 wheel"
+          command: python setup.py bdist_wheel
+
+  upload_pplbench:
+    steps:
+      - run:
+          name: "Upload PPL Bench to PyPI using twine"
+          no_output_timeout: 30m
+          command: twine upload dist/* --disable-progress-bar
 
 jobs:
 
@@ -96,6 +114,15 @@ jobs:
       - pip_install_pplbench_all
       - run_example_json
 
+  package_and_upload_pplbench:
+    docker:
+      - image: circleci/python:3.7
+    steps:
+      - checkout
+      - upgrade_pip
+      - package_pplbench
+      - upload_pplbench
+
 aliases:
 
   - &exclude_ghpages_fbconfig
@@ -104,12 +131,31 @@ aliases:
         - gh-pages
         - fb-config
 
+  - &versioned_tags_only
+    branches:
+      # to prevent CircleCI from starting a workflow run for each branch
+      ignore: /.*/
+    tags:
+      # See PEP 440 version scheme: https://www.python.org/dev/peps/pep-0440/#version-scheme
+      only: /^v([1-9][0-9]*!)?(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*((a|b|rc)(0|[1-9][0-9]*))?(\.post(0|[1-9][0-9]*))?(\.dev(0|[1-9][0-9]*))?$/
 
 workflows:
 
-  lint:
+  lint_and_test:
     jobs:
       - lint_py37_pip:
           filters: *exclude_ghpages_fbconfig
       - test_example_json_py37_pip:
           filters: *exclude_ghpages_fbconfig
+
+  build_and_deploy:
+    jobs:
+      - lint_py37_pip:
+          filters: *versioned_tags_only
+      - test_example_json_py37_pip:
+          filters: *versioned_tags_only
+      - package_and_upload_pplbench:
+          filters: *versioned_tags_only
+          requires:
+            - lint_py37_pip
+            - test_example_json_py37_pip


### PR DESCRIPTION
Summary: When a new tag is created with name "v" + a version number that matches [PEP 440 version scheme](https://www.python.org/dev/peps/pep-0440/#version-scheme) (e.g. `v0.0.1`), a workflow will be triggered on CircleCI that automatically tests, builds, and deploys `pplbench` to [PyPI](https://pypi.org/project/pplbench/).

Differential Revision: D24470235

