### PR TITLE
Adding CircleCI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ![](docs/assets/logo.png)
 
+[![facebookresearch](https://circleci.com/gh/facebookresearch/pplbench.svg?style=svg)](https://app.circleci.com/pipelines/github/facebookresearch/pplbench)
 
 # Getting Started with PPL Bench
 


### PR DESCRIPTION
Summary:
Display CircleCI status badge (see image below) on readme page to allow user see the status of master branch at a glance.

![image](https://user-images.githubusercontent.com/18493382/96935127-4e773b80-1478-11eb-877e-b2a66aad97de.png)


Differential Revision: D24488116

