### PR TITLE
Bump version number to 0.0.1

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,0 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
-
-__version__ = "0.0.1a1"

--- a/pplbench/__init__.py
+++ b/pplbench/__init__.py
@@ -1,1 +1,3 @@
 # Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+
+__version__ = "0.0.1"

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ if sys.version_info < (REQUIRED_MAJOR, REQUIRED_MINOR):
 
 # get version string from module
 current_dir = os.path.dirname(__file__)
-init_file = os.path.join(current_dir, "__init__.py")
+init_file = os.path.join(current_dir, "pplbench", "__init__.py")
 version_regexp = r"__version__ = ['\"]([^'\"]*)['\"]"
 with open(init_file, "r") as f:
     version = re.search(version_regexp, f.read(), re.M).group(1)


### PR DESCRIPTION
Summary: As titled. Bump the version number of pplbench from `0.0.1a1` to `0.0.1` to prepare for PyPI package and remove the repo-level `__init__.py` file.

Differential Revision: D24489762

