### PR TITLE
Include adaptive samples in plots and exclude them from diagnostics

### DIFF
--- a/examples/logistic_regression.json
+++ b/examples/logistic_regression.json
@@ -48,7 +48,7 @@
         "class": "inference.VI",
         "infer_args": {"algorithm": "FullRankADVI"}
       },
-      "legend": {"color": "darkseagreen", "name": "pymc3-full"}
+      "legend": {"color": "darkseagreen", "name": "pymc3-VI-full"}
     },
     {
       "name": "numpyro",

--- a/pplbench/lib/reports.py
+++ b/pplbench/lib/reports.py
@@ -46,6 +46,14 @@ def generate_plots(
         "pll_quarter",
     )
 
+    generate_pll_plot(
+        config,
+        output_dir,
+        all_ppl_details,
+        all_other_metrics_data.pll.isel(draw=slice(config.num_warmup, None)),
+        "pll_post_warmup",
+    )
+
 
 def generate_pll_plot(
     config: SimpleNamespace,
@@ -59,24 +67,23 @@ def generate_pll_plot(
         if hasattr(config, "figures") and hasattr(config.figures, "suffix")
         else "png"
     )
-    min_pll = pll.min("chain")
-    max_pll = pll.max("chain")
-    mean_pll = pll.mean("chain")
     plt.figure(figsize=(8, 6))
     plt.rcParams.update({"font.size": 18})
 
     legend = []
     for ppl_details in all_ppl_details:
+        valid_pll = pll.sel(ppl=ppl_details.name).dropna("draw")
+
         (line,) = plt.plot(
-            pll.coords["draw"],
-            mean_pll.sel(ppl=ppl_details.name),
+            valid_pll.coords["draw"],
+            valid_pll.mean("chain"),
             color=ppl_details.color,
             label=ppl_details.name,
         )
         plt.fill_between(
-            pll.coords["draw"],
-            min_pll.sel(ppl=ppl_details.name),
-            max_pll.sel(ppl=ppl_details.name),
+            valid_pll.coords["draw"],
+            valid_pll.min("chain"),
+            valid_pll.max("chain"),
             color=ppl_details.color,
             interpolate=True,
             alpha=0.3,

--- a/pplbench/main.py
+++ b/pplbench/main.py
@@ -35,6 +35,7 @@ SCHEMA = {
             "additionalProperties": False,
         },
         "num_samples": {"type": "integer", "minimum": 1},
+        "num_warmup": {"type": "integer", "minimum": 0},
         "trials": {"type": "integer", "minimum": 2},
         "ppls": {
             "type": "array",
@@ -46,6 +47,7 @@ SCHEMA = {
                         "type": "object",
                         "properties": {
                             "class": {"type": "string"},
+                            "num_warmup": {"type": "integer", "minimum": 0},
                             "compile_args": {
                                 "type": "object",
                                 "propertyNames": {
@@ -140,6 +142,11 @@ def read_config(args: Optional[List[str]]) -> SimpleNamespace:
     parser = ArgumentParser()
     parser.add_argument("config", action=ActionJsonSchema(schema=SCHEMA), help="%s")
     config = parser.parse_args(args).config
+
+    # default num_warmup to half of num_sample
+    if not hasattr(config, "num_warmup"):
+        config.num_warmup = config.num_samples // 2
+
     return config
 
 

--- a/pplbench/ppls/base_ppl_inference.py
+++ b/pplbench/ppls/base_ppl_inference.py
@@ -8,6 +8,17 @@ from .base_ppl_impl import BasePPLImplementation
 
 
 class BasePPLInference(ABC):
+    """
+    The base class of all PPL inference methods.
+
+    Attributes:
+        is_adaptive: A boolean indicates whether the inference method is adaptive or
+        not. The default value for is_adaptive is True. See infer() to see how this
+        attribute should be used.
+    """
+
+    is_adaptive = True
+
     @abstractmethod
     def __init__(
         self, impl_class: Type[BasePPLImplementation], model_attrs: Dict
@@ -26,9 +37,23 @@ class BasePPLInference(ABC):
 
     @abstractmethod
     def infer(
-        self, data: xr.Dataset, num_samples: int, seed: int, **infer_args
+        self,
+        data: xr.Dataset,
+        num_samples: int,
+        num_warmup: int,
+        seed: int,
+        **infer_args
     ) -> xr.Dataset:
-        """Run inference and return samples"""
+        """
+        Run inference and return samples. The number of samples returned by this method
+        should equal to num_samples. If is_adaptive is True for the class, PPL Bench
+        will assume that the samples with indicies [0, num_warmup) are warm up and
+        samples in [num_warmup, num_samples) will be used to compute diagnostic metrics.
+        Algorithms that do not use warm up samples should set is_adaptive to False when
+        extending this base class and could ignore num_warmup parameter when overriding
+        infer(). When is_adaptive is set to False, all samples in [0, num_samples) are
+        treated as valid samples and will be included in diagnostics.
+        """
         raise NotImplementedError
 
     def additional_diagnostics(self, output_dir: str, prefix: str) -> None:

--- a/pplbench/ppls/numpyro/inference.py
+++ b/pplbench/ppls/numpyro/inference.py
@@ -30,6 +30,7 @@ class MCMC(BaseNumPyroInference):
         self,
         data: xr.Dataset,
         num_samples: int,
+        num_warmup: int,
         seed: int,
         algorithm: str = "NUTS",
         **infer_args,
@@ -41,10 +42,11 @@ class MCMC(BaseNumPyroInference):
             kernel = infer.NUTS(self.impl.model)
         else:
             raise ValueError(f"{algorithm} algorithm not registered for NumPyro.")
-        num_warmup = num_samples // 2
-        num_samples -= num_warmup
         mcmc = infer.MCMC(
-            kernel, num_warmup=num_warmup, num_samples=num_samples, **infer_args
+            kernel,
+            num_warmup=num_warmup,
+            num_samples=num_samples - num_warmup,
+            **infer_args,
         )
         # Note that we need to run warmup separately to collect samples
         # from the warmup phase.


### PR DESCRIPTION
Summary:
There are several changes in this commit:

- Add a global config option called `num_warmup`, which is at the same level of `num_samples`. If `num_warmup` is not provided, the default value is half of `num_samples`.
- Users can overwrite the global `num_warmup` for each PPL by setting the per-PPL config, so that users can compare the same algorithm with different warmup samples
- The warmup samples are included in the PLL plots, but they are excluded from diagnostic metric calculation (except for PyJags, which does not seem to provide an interface for getting those samples back)

Sample plots:

`pll.png`
![image](https://user-images.githubusercontent.com/18493382/98748387-67d02100-236e-11eb-887e-e65c8bee9110.png)

`pll_three_quarter.png`
![image](https://user-images.githubusercontent.com/18493382/98748403-70c0f280-236e-11eb-9285-a5e090b40533.png)


Differential Revision: D24580278

