### PR TITLE
Fix a condition check on PyPI release workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,10 +118,11 @@ jobs:
       id: version
       run: |
         VERSION_TAG="v$(python setup.py --version)"
-        if  [[ $(git tag -l $VERSION_TAG) ]]; then
-          echo "::set-output name=has_updated::true"
-        else
+        if  [[ $(git ls-remote --tags origin refs/tags/$VERSION_TAG) ]]; then
+          # there exists a tag with same name as current version
           echo "::set-output name=has_updated::false"
+        else
+          echo "::set-output name=has_updated::true"
         fi
         echo "::set-output name=version_tag::$(echo $VERSION_TAG)"
         echo "The current version of PPL Bench is $VERSION_TAG"


### PR DESCRIPTION
Summary:
1. There was a small bug in the PyPI release workflow where I accidentally inverted the true/false condition on whether a new version should be released or not.
2. However, (1) means that the workflow should've been triggered. The only reason it wasn't is that, by default, the `checkout` action only pull the latest commit without any history... [so using `git tag` in workflow does not return anything](https://github.com/actions/checkout/issues/100)
3. To fix (2), we should use `git ls-remote` to check the existing tags on GitHub (instead of listing the local ones). Cloning the repo with full history also works, but is much less efficient.

This is how it would look like in README.md:

![image](https://user-images.githubusercontent.com/18493382/97937487-b1e45180-1d33-11eb-8ed9-ef02fae67352.png)


Differential Revision: D24696408

