### PR TITLE
Fix serialization issue on Namespace type

### DIFF
--- a/pplbench/lib/utils.py
+++ b/pplbench/lib/utils.py
@@ -7,6 +7,7 @@ import os
 import pydoc
 import sys
 import time
+from argparse import Namespace
 from types import SimpleNamespace
 from typing import Any
 
@@ -35,7 +36,7 @@ class SimpleNamespaceEncoder(json.JSONEncoder):
     """define class for encoding config object"""
 
     def default(self, object):
-        if isinstance(object, SimpleNamespace):
+        if isinstance(object, SimpleNamespace) or isinstance(object, Namespace):
             return object.__dict__
         elif isinstance(object, jsonargparse.Path):
             return {}

--- a/pplbench/models/crowd_sourced_annotation.py
+++ b/pplbench/models/crowd_sourced_annotation.py
@@ -160,7 +160,8 @@ class CrowdSourcedAnnotation(BaseModel):
         confusion_matrix = samples.confusion_matrix.values
         labels = test.labels.values
         labelers = test.labelers.values
-        # size of confusion_matrix[:, labelers, :, labels]: [n/2, num_categories, iterations, num_categories]
+        # size of confusion_matrix[:, labelers, :, labels]
+        # is [n/2, num_categories, iterations, num_categories]
         likelihood = logsumexp(
             np.log(confusion_matrix[:, labelers, :, labels]).sum(axis=1) + np.log(prev),
             axis=2,


### PR DESCRIPTION
Summary:
`jsonargparse` switched to use `Namespace` type instead of `SimpleNamespace`, which cause PPL Bench to break when it tries to serialize the config to the output directory.

This commit is a quick fix so both `SimpleNamespace` and `Namespace` can be serialize without error. In the future we might want to [`jsonargparse.util.namespace_to_dict`](https://omni-us.github.io/jsonargparse/index.html#jsonargparse.util.namespace_to_dict) after updating the version of `jsonargparse` used internally.

Differential Revision: D25856745

