### PR TITLE
Make CI linting consistent by switching to usort (#884)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,19 +30,17 @@ jobs:
       run: python -m pip install --upgrade pip
 
     - name: Install linters
-      run: pip install black==20.8b1 isort==4.3.21 flake8==3.8.1 mypy==0.782
+      run: pip install black==20.8b1 usort flake8==3.8.1 mypy==0.782
 
     - name: Lint with flake8
       run: flake8 .
 
-    - name: Lint with isort
+    - name: Lint with usort
       run: >-
-        isort --check-only --diff --line-width=88 --multi-line=3
-        --trailing-comma --force-grid-wrap=0 --section-default=THIRDPARTY
-        --lines-after-imports=2 --combine-as
+        usort check .
 
     - name: Lint with black
-      run: black --check --diff --line-length=88 .
+      run: black --check .
 
     - name: Install PPL Bench core
       run: pip install .

--- a/pplbench/lib/ppl_helper.py
+++ b/pplbench/lib/ppl_helper.py
@@ -140,7 +140,7 @@ def collect_samples_and_stats(
         # compile step 1: instantiate ppl inference object
         infer_obj = pplobj.inference_class(pplobj.impl_class, train_data.attrs)
         # compile step 2: call compile
-        infer_obj.compile(seed=rand.randint(1, 1e7), **pplobj.compile_args)
+        infer_obj.compile(seed=rand.randint(1, int(1e7)), **pplobj.compile_args)
         compile_time = time.time() - compile_t1
         LOGGER.info(f"compiling on `{pplobj.name}` took {compile_time:.2f} secs")
 
@@ -170,7 +170,7 @@ def collect_samples_and_stats(
                 data=train_data,
                 iterations=config.iterations,
                 num_warmup=num_warmup,
-                seed=rand.randint(1, 1e7),
+                seed=rand.randint(1, int(1e7)),
                 **pplobj.infer_args,
             )
             infer_time = time.time() - infer_t1

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ PPLS_REQUIRE = [
     "pyro-ppl>=0.4.1",
     "numpyro>=0.3.0",
 ]
-DEV_REQUIRE = PPLS_REQUIRE + ["black==20.8b1", "isort", "flake8", "mypy"]
+DEV_REQUIRE = PPLS_REQUIRE + ["black==20.8b1", "flake8", "mypy", "usort"]
 
 
 # Check for python version


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/beanmachine/pull/884

Phabricator linting https://www.internalfb.com/intern/wiki/Linting/fbsource-linters/ uses pyfmt (https://fb.workplace.com/groups/pyfmt/), a combination of black and usort. However, CircleCI uses black and **isort** and has resulted in toil such as https://www.internalfb.com/intern/diff/D29397720/.

By switching the project's linter to usort, this moves us closer to having consistent CI checks between phabricator and circleci.

Reviewed By: ericlippert, horizon-blue

Differential Revision: D29398738

