### PR TITLE
Fix PyPI publish workflow (#74)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -154,7 +154,7 @@ jobs:
       run: python setup.py bdist_wheel
 
     - name: Upload PPL Bench to PyPI
-      uses: pypa/gh-action-pypi-publish@main
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI_PASSWORD }}
 


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookincubator/flowtorch/pull/74

Just noticed that we're referring a no-existing "main" version of `pypa/gh-action-pypi-publish`. This is probably an artifact when we renamed `master` branch to `main` on our own repo. Since [pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish/tree/master) doesn't have a main branch, this will likely error out the next time we run the PyPI publish workflow.

Differential Revision: D32006423

