### PR TITLE
Changes to be compatible with jsonargparse v4

### DIFF
--- a/pplbench/lib/utils.py
+++ b/pplbench/lib/utils.py
@@ -7,7 +7,6 @@ import os
 import pydoc
 import sys
 import time
-from argparse import Namespace
 from types import SimpleNamespace
 from typing import Any
 
@@ -36,7 +35,7 @@ class SimpleNamespaceEncoder(json.JSONEncoder):
     """define class for encoding config object"""
 
     def default(self, object):
-        if isinstance(object, SimpleNamespace) or isinstance(object, Namespace):
+        if isinstance(object, SimpleNamespace):
             return object.__dict__
         elif isinstance(object, jsonargparse.Path):
             return {}

--- a/pplbench/main.py
+++ b/pplbench/main.py
@@ -4,6 +4,7 @@ import os
 import sys
 from types import SimpleNamespace
 from typing import List, Optional
+from unittest import mock
 
 from jsonargparse import ActionJsonSchema, ArgumentParser, dict_to_namespace
 
@@ -142,10 +143,8 @@ def read_config(args: Optional[List[str]]) -> SimpleNamespace:
     parser = ArgumentParser()
     parser.add_argument("config", action=ActionJsonSchema(schema=SCHEMA), help="%s")
     config = parser.parse_args(args).config
-    if isinstance(config, dict):
-        from unittest import mock
-        with mock.patch("jsonargparse.namespace.Namespace", SimpleNamespace):
-            config = dict_to_namespace(config)
+    with mock.patch("jsonargparse.namespace.Namespace", SimpleNamespace):
+        config = dict_to_namespace(config)
 
     # default num_warmup to half of num_sample
     if not hasattr(config, "num_warmup"):

--- a/pplbench/main.py
+++ b/pplbench/main.py
@@ -5,7 +5,7 @@ import sys
 from types import SimpleNamespace
 from typing import List, Optional
 
-from jsonargparse import ActionJsonSchema, ArgumentParser
+from jsonargparse import ActionJsonSchema, ArgumentParser, dict_to_namespace
 
 from .lib import model_helper, ppl_helper, reports, utils
 
@@ -142,6 +142,10 @@ def read_config(args: Optional[List[str]]) -> SimpleNamespace:
     parser = ArgumentParser()
     parser.add_argument("config", action=ActionJsonSchema(schema=SCHEMA), help="%s")
     config = parser.parse_args(args).config
+    if isinstance(config, dict):
+        from unittest import mock
+        with mock.patch("jsonargparse.namespace.Namespace", SimpleNamespace):
+            config = dict_to_namespace(config)
 
     # default num_warmup to half of num_sample
     if not hasattr(config, "num_warmup"):

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
     long_description_content_type="text/markdown",
     python_requires=">=3.7",
     install_requires=[
-        "jsonargparse>=2.32.2",
+        "jsonargparse>=4.0.0",
         "jsonschema>=3.2.0",
         "numpy>=1.18.5",
         "scipy>=1.5.0",


### PR DESCRIPTION
### Motivation
I have noticed that this project has as dependency jsonargparse and makes use of the `ActionJsonSchema` class. Scheduled for tomorrow (Nov 16th 2021) jsonargparse v4.0.0 will be released and it includes a breaking change in the behavior of `ActionJsonSchema`. The change is that the values parsed with this action will no longer be a nested namespace but a nested dict instead.

### Changes proposed
This pull request includes a small change so that there is compatibility with the newer versions of jsonargparse.

### Test Plan
I tested by using `pplbench examples/example.json` with jsonargparse v4.0.0rc1 making sure that it worked just like with previous versions.

### Types of changes
- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](https://github.com/facebookresearch/pplbench/blob/main/CONTRIBUTING.md)** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] The title of my pull request is a short description of the requested changes.
