### PR TITLE
Enable License Lint for Bean Machine and PPL Bench (#1316)

### DIFF
--- a/pplbench/__init__.py
+++ b/pplbench/__init__.py
@@ -1,3 +1,6 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 __version__ = "0.0.2"

--- a/pplbench/__main__.py
+++ b/pplbench/__main__.py
@@ -1,4 +1,8 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import os
 import sys
 

--- a/pplbench/lib/__init__.py
+++ b/pplbench/lib/__init__.py
@@ -1,1 +1,4 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/pplbench/lib/model_helper.py
+++ b/pplbench/lib/model_helper.py
@@ -1,4 +1,8 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import logging
 import time
 from types import SimpleNamespace

--- a/pplbench/lib/ppl_helper.py
+++ b/pplbench/lib/ppl_helper.py
@@ -1,4 +1,8 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import hashlib
 import logging
 import struct

--- a/pplbench/lib/reports.py
+++ b/pplbench/lib/reports.py
@@ -1,4 +1,8 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import os
 from types import SimpleNamespace
 from typing import List

--- a/pplbench/lib/utils.py
+++ b/pplbench/lib/utils.py
@@ -1,4 +1,8 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import datetime
 import io
 import json

--- a/pplbench/main.py
+++ b/pplbench/main.py
@@ -1,4 +1,8 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import logging
 import os
 import sys

--- a/pplbench/models/__init__.py
+++ b/pplbench/models/__init__.py
@@ -1,1 +1,4 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/pplbench/models/base_model.py
+++ b/pplbench/models/base_model.py
@@ -1,4 +1,8 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 from abc import ABC, abstractmethod
 from typing import Tuple
 

--- a/pplbench/models/crowd_sourced_annotation.py
+++ b/pplbench/models/crowd_sourced_annotation.py
@@ -1,4 +1,7 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from typing import Tuple
 

--- a/pplbench/models/logistic_regression.py
+++ b/pplbench/models/logistic_regression.py
@@ -1,4 +1,8 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import logging
 from typing import Tuple
 

--- a/pplbench/models/n_schools.py
+++ b/pplbench/models/n_schools.py
@@ -1,4 +1,8 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import logging
 from typing import Tuple
 

--- a/pplbench/models/noisy_or_topic.py
+++ b/pplbench/models/noisy_or_topic.py
@@ -1,4 +1,8 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import logging
 from typing import Tuple
 

--- a/pplbench/models/robust_regression.py
+++ b/pplbench/models/robust_regression.py
@@ -1,4 +1,8 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import logging
 from typing import Tuple
 

--- a/pplbench/models/utils.py
+++ b/pplbench/models/utils.py
@@ -1,4 +1,8 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 from typing import Tuple
 
 import numpy as np

--- a/pplbench/ppls/__init__.py
+++ b/pplbench/ppls/__init__.py
@@ -1,1 +1,4 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/pplbench/ppls/base_ppl_impl.py
+++ b/pplbench/ppls/base_ppl_impl.py
@@ -1,4 +1,8 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 from abc import ABC, abstractmethod
 
 

--- a/pplbench/ppls/base_ppl_inference.py
+++ b/pplbench/ppls/base_ppl_inference.py
@@ -1,4 +1,8 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 from abc import ABC, abstractmethod
 from typing import Dict, Type
 

--- a/pplbench/ppls/jags/__init__.py
+++ b/pplbench/ppls/jags/__init__.py
@@ -1,1 +1,4 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/pplbench/ppls/jags/base_jags_impl.py
+++ b/pplbench/ppls/jags/base_jags_impl.py
@@ -1,4 +1,8 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 from abc import abstractmethod
 from typing import Dict, List
 

--- a/pplbench/ppls/jags/inference.py
+++ b/pplbench/ppls/jags/inference.py
@@ -1,4 +1,8 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 from typing import Dict, Type, cast
 
 import numpy as np

--- a/pplbench/ppls/jags/logistic_regression.py
+++ b/pplbench/ppls/jags/logistic_regression.py
@@ -1,4 +1,8 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 from typing import Dict, List
 
 import numpy as np

--- a/pplbench/ppls/jags/n_schools.py
+++ b/pplbench/ppls/jags/n_schools.py
@@ -1,4 +1,8 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 from typing import Dict, List
 
 import numpy as np

--- a/pplbench/ppls/jags/noisy_or_topic.py
+++ b/pplbench/ppls/jags/noisy_or_topic.py
@@ -1,4 +1,8 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import logging
 from typing import Dict, List
 

--- a/pplbench/ppls/jags/robust_regression.py
+++ b/pplbench/ppls/jags/robust_regression.py
@@ -1,4 +1,8 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 from typing import Dict, List
 
 import numpy as np

--- a/pplbench/ppls/numpyro/__init__.py
+++ b/pplbench/ppls/numpyro/__init__.py
@@ -1,1 +1,4 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/pplbench/ppls/numpyro/base_numpyro_impl.py
+++ b/pplbench/ppls/numpyro/base_numpyro_impl.py
@@ -1,4 +1,7 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from abc import abstractmethod
 from typing import Dict

--- a/pplbench/ppls/numpyro/inference.py
+++ b/pplbench/ppls/numpyro/inference.py
@@ -1,4 +1,7 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from typing import Dict, Type, cast
 

--- a/pplbench/ppls/numpyro/logistic_regression.py
+++ b/pplbench/ppls/numpyro/logistic_regression.py
@@ -1,4 +1,7 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from typing import Dict
 

--- a/pplbench/ppls/pymc3/__init__.py
+++ b/pplbench/ppls/pymc3/__init__.py
@@ -1,1 +1,4 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/pplbench/ppls/pymc3/base_pymc3_impl.py
+++ b/pplbench/ppls/pymc3/base_pymc3_impl.py
@@ -1,4 +1,8 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 from abc import abstractmethod
 
 import pymc3 as pm

--- a/pplbench/ppls/pymc3/inference.py
+++ b/pplbench/ppls/pymc3/inference.py
@@ -1,4 +1,7 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from typing import Dict, Type, cast
 

--- a/pplbench/ppls/pymc3/logistic_regression.py
+++ b/pplbench/ppls/pymc3/logistic_regression.py
@@ -1,4 +1,8 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import numpy as np
 import pymc3 as pm
 import xarray as xr

--- a/pplbench/ppls/pymc3/noisy_or_topic.py
+++ b/pplbench/ppls/pymc3/noisy_or_topic.py
@@ -1,4 +1,8 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 from typing import Dict
 
 import numpy as np

--- a/pplbench/ppls/pymc3/robust_regression.py
+++ b/pplbench/ppls/pymc3/robust_regression.py
@@ -1,4 +1,8 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import numpy as np
 import pymc3 as pm
 import xarray as xr

--- a/pplbench/ppls/stan/__init__.py
+++ b/pplbench/ppls/stan/__init__.py
@@ -1,1 +1,4 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/pplbench/ppls/stan/base_stan_impl.py
+++ b/pplbench/ppls/stan/base_stan_impl.py
@@ -1,4 +1,8 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 from abc import abstractmethod
 from typing import Dict, List
 

--- a/pplbench/ppls/stan/crowd_sourced_annotation.py
+++ b/pplbench/ppls/stan/crowd_sourced_annotation.py
@@ -1,4 +1,8 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 from typing import Dict, List
 
 import numpy as np

--- a/pplbench/ppls/stan/inference.py
+++ b/pplbench/ppls/stan/inference.py
@@ -1,4 +1,8 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 from collections import OrderedDict
 from typing import Dict, Type, cast
 

--- a/pplbench/ppls/stan/logistic_regression.py
+++ b/pplbench/ppls/stan/logistic_regression.py
@@ -1,4 +1,8 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 from typing import Dict, List
 
 import numpy as np

--- a/pplbench/ppls/stan/n_schools.py
+++ b/pplbench/ppls/stan/n_schools.py
@@ -1,4 +1,8 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 from typing import Dict, List
 
 import numpy as np

--- a/pplbench/ppls/stan/noisy_or_topic.py
+++ b/pplbench/ppls/stan/noisy_or_topic.py
@@ -1,4 +1,8 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 from typing import Dict, List
 
 import numpy as np

--- a/pplbench/ppls/stan/robust_regression.py
+++ b/pplbench/ppls/stan/robust_regression.py
@@ -1,4 +1,8 @@
-# Copyright(C) Facebook, Inc. and its affiliates. All Rights Reserved.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 from typing import Dict, List
 
 import numpy as np

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,7 @@
-# Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import os
 import re

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,8 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 from typing import Optional, Tuple
 
 import torch

--- a/website/.docusaurus/client-modules.js
+++ b/website/.docusaurus/client-modules.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 export default [
   require("/Users/dvinnik/work/ppl/pplbench/website/node_modules/remark-admonitions/styles/infima.css"),
   require("/Users/dvinnik/work/ppl/pplbench/website/node_modules/remark-admonitions/styles/infima.css"),

--- a/website/.docusaurus/docusaurus.config.js
+++ b/website/.docusaurus/docusaurus.config.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 export default {
   "title": "PPL Bench",
   "tagline": "Evaluation Framework for Probabilistic Programming Languages",

--- a/website/.docusaurus/routes.js
+++ b/website/.docusaurus/routes.js
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 import React from 'react';
 import ComponentCreator from '@docusaurus/ComponentCreator';

--- a/website/babel.config.js
+++ b/website/babel.config.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,11 +1,12 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
  * @format
  */
+
 const remarkMath = require('remark-math');
 const rehypeKatex = require('rehype-katex');
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/src/pages/styles.module.css
+++ b/website/src/pages/styles.module.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/static/css/code_block_buttons.css
+++ b/website/static/css/code_block_buttons.css
@@ -1,4 +1,10 @@
-/* Copyright (c) Facebook, Inc. and its affiliates. */
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 pre {
   position: relative;
 }

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/website/static/js/code_block_buttons.js
+++ b/website/static/js/code_block_buttons.js
@@ -1,4 +1,10 @@
-// Copyright (c) Facebook, Inc. and its affiliates.
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 // Turn off ESLint for this file because it's sent down to users as-is.
 /* eslint-disable */
 window.addEventListener('load', function() {

--- a/website/static/js/mathjax.js
+++ b/website/static/js/mathjax.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates.
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 window.MathJax = {
   tex2jax: {

--- a/website/static/pygments.css
+++ b/website/static/pygments.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookresearch/beanmachine/pull/1316

This diff enable license lint for Bean Machine and PPL Bench, which will enforce a copyright statement on top of every file under PPL Team's codebase. This will also give us a diff-time warning so we can avoid accidentally committing codes without the license and failing OSS requirement (such as T110683359).

I was hoping to enable this linter for a while so we don't have to keeping track of the headers manually, but license lint was using the "Facebook" variant of the headers. Now that it's updated to use "Meta," we can safely enable it for our project without having to do a major codemod later on :).

In addition to enabling the linter, this diff also updates the few files that failed the license requirement. These have to be done in the same diff to make the linter happy.

Reviewed By: neerajprad

Differential Revision: D33772236

