### PR TITLE
Fix broken link in documentation

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -4,7 +4,7 @@ title: Getting Started
 ---
 This document outlines how to get started with PPL Bench.
 
-Before jumping into the project, we recommend you read ["Why Bean Machine?"](why_bean_machine.md) and [System Overview](system_overview.md) documents.
+Before jumping into the project, we recommend you read [Introduction](introduction.md) and [System Overview](system_overview.md) documents.
 
 ## Installation
 

--- a/pplbench/ppls/jags/inference.py
+++ b/pplbench/ppls/jags/inference.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Dict, Type, cast
+from typing import cast, Dict, Type
 
 import numpy as np
 import pyjags

--- a/pplbench/ppls/numpyro/inference.py
+++ b/pplbench/ppls/numpyro/inference.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Dict, Type, cast
+from typing import cast, Dict, Type
 
 import numpy as np
 import numpyro.infer as infer

--- a/pplbench/ppls/pymc3/inference.py
+++ b/pplbench/ppls/pymc3/inference.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Dict, Type, cast
+from typing import cast, Dict, Type
 
 import pymc3 as pm
 import xarray as xr

--- a/pplbench/ppls/stan/inference.py
+++ b/pplbench/ppls/stan/inference.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from collections import OrderedDict
-from typing import Dict, Type, cast
+from typing import cast, Dict, Type
 
 import numpy as np
 import xarray as xr


### PR DESCRIPTION
Summary: In D32900373 (https://github.com/facebookresearch/pplbench/commit/357902eea52ffa36295b930e169e1a096bdc1c24) we accidentally edited a documentation in PPL Bench and pointed it to a non-existing page. This diff reverted the link to its original state and (hopefully) fix the doc building workflow.

Reviewed By: jpchen

Differential Revision: D33714972

