### PR TITLE
Fix linting workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,17 +31,15 @@ jobs:
       run: python -m pip install --upgrade pip
 
     - name: Install linters
-      run: pip install black==20.8b1 usort flake8==3.8.1 mypy==0.782
+      run: >
+        pip install black==21.4b2 flake8==4.0.1 libcst==0.4.1 ufmt==1.3.2 usort==0.6.4
+        mypy==0.782 click==8.0.4
 
     - name: Lint with flake8
       run: flake8 .
 
-    - name: Lint with usort
-      run: >-
-        usort check .
-
-    - name: Lint with black
-      run: black --check .
+    - name: Lint with ufmt (black + usort)
+      run: ufmt check .
 
     - name: Install PPL Bench core
       run: pip install .

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ PPLS_REQUIRE = [
     "numpyro>=0.3.0",
     "beanmachine>=0.1.1",
 ]
-DEV_REQUIRE = PPLS_REQUIRE + ["black==20.8b1", "flake8", "mypy", "usort"]
+DEV_REQUIRE = PPLS_REQUIRE + ["black==21.4b2", "flake8", "mypy", "usort"]
 
 
 # Check for python version


### PR DESCRIPTION
Summary:
As reported by mootaz77, in D35833204 (https://github.com/facebookresearch/pplbench/commit/1df1353c520c9a0f848e2896e0cb2121d53626d8), our lint workflow fails because the version of `black` that we pinned in PPL Bench is incompatible with the latest `click`.

This incompatibility issue should have been resolved in a newer version of `black` (see https://github.com/psf/black/issues/2964 for relevant discussion), so to fix it, we will need to bump our dependency to a version newer than 22.3.0.

However, our internal Python formatter is pinned to `black==21.4b2` at the moment, and upgrading to a newer version could result in internal vs external inconsistency. Therefore, to work around the issue, we'll need to pin `click` to an older version, as suggested by the GitHub issue linked above.

Differential Revision: D36259748

