### PR TITLE
Bump black to 22.3.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,8 +32,8 @@ jobs:
 
     - name: Install linters
       run: >
-        pip install black==21.4b2 flake8==4.0.1 libcst==0.4.1 ufmt==1.3.2 usort==0.6.4
-        mypy==0.782 click==8.0.4
+        pip install black==22.3.0 flake8==4.0.1 libcst==0.4.1 ufmt==1.3.2 usort==0.6.4
+        mypy==0.782
 
     - name: Lint with flake8
       run: flake8 .

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,68 @@
 [flake8]
-# E203: black and flake8 disagree on whitespace before ':'
-# W503: black and flake8 disagree on how to place operators
-ignore = E203, W503, E741
-max-line-length = 105
+select = B,C,E,F,P,W,B9
+max-line-length = 80
+# Main Explanation Docs: https://github.com/grantmcconnaughey/Flake8Rules
+ignore =
+  # Black conflicts and overlaps.
+  # Found in https://github.com/psf/black/issues/429
+  B950, # Line too long.
+  E111, # Indentation is not a multiple of four.
+  E115, # Expected an indented block (comment).
+  E117, # Over-indented.
+  E121, # Continuation line under-indented for hanging indent.
+  E122, # Continuation line missing indentation or outdented.
+  E123, # Closing bracket does not match indentation of opening bracket's line.
+  E124, # Closing bracket does not match visual indentation.
+  E125, # Continuation line with same indent as next logical line.
+  E126, # Continuation line over-indented for hanging indent.
+  E127, # Continuation line over-indented for visual indent.
+  E128, # Continuation line under-indented for visual indent.
+  E129, # Visually indented line with same indent as next logical line.
+  E201, # Whitespace after '('.
+  E202, # Whitespace before ')'.
+  E203, # Whitespace before ':'.
+  E221, # Multiple spaces before operator.
+  E222, # Multiple spaces after operator.
+  E225, # Missing whitespace around operator.
+  E226, # Missing whitespace around arithmetic operator.
+  E227, # Missing whitespace around bitwise or shift operator.
+  E231, # Missing whitespace after ',', ';', or ':'.
+  E241, # Multiple spaces after ','.
+  E251, # Unexpected spaces around keyword / parameter equals.
+  E261, # At least two spaces before inline comment.
+  E262, # Inline comment should start with '# '.
+  E265, # Block comment should start with '# '.
+  E271, # Multiple spaces after keyword.
+  E272, # Multiple spaces before keyword.
+  E301, # Expected 1 blank line, found 0.
+  E302, # Expected 2 blank lines, found 0.
+  E303, # Too many blank lines (3).
+  E305, # Expected 2 blank lines after end of function or class.
+  E306, # Expected 1 blank line before a nested definition.
+  E501, # Line too long (82 > 79 characters).
+  E502, # The backslash is redundant between brackets.
+  E701, # Multiple statements on one line (colon).
+  E702, # Multiple statements on one line (semicolon).
+  E703, # Statement ends with a semicolon.
+  E704, # Multiple statements on one line (def).
+  W291, # Trailing whitespace.
+  W292, # No newline at end of file.
+  W293, # Blank line contains whitespace.
+  W391, # Blank line at end of file.
+
+  # Too opinionated.
+  E265, # Block comment should start with '# '.
+  E266, # Too many leading '#' for block comment.
+  E402, # Module level import not at top of file.
+  E722, # Do not use bare except, specify exception instead. (Duplicate of B001)
+  F811, # Redefinition of unused name from line n.
+  P207, # (Duplicate of B003)
+  P208, # (Duplicate of C403)
+  W503  # Line break occurred before a binary operator.
+max-complexity = 12
+exclude =
+  build, dist, tutorials, website
+
 [mypy-jsonargparse.*]
 ignore_missing_imports = True
 [mypy-pandas.*]

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ PPLS_REQUIRE = [
     "numpyro>=0.3.0",
     "beanmachine>=0.1.1",
 ]
-DEV_REQUIRE = PPLS_REQUIRE + ["black==21.4b2", "flake8", "mypy", "usort"]
+DEV_REQUIRE = PPLS_REQUIRE + ["black==22.3.0", "flake8", "mypy", "usort"]
 
 
 # Check for python version


### PR DESCRIPTION
Summary: Update the formatter following D36324783 (https://github.com/facebookresearch/pplbench/commit/d9720228024b66191d1f312617fe79b2981fa8ca) to clear the lint exceptions

Differential Revision: D36337516

