### PR TITLE
Bump version to v0.0.3

### DIFF
--- a/pplbench/__init__.py
+++ b/pplbench/__init__.py
@@ -3,4 +3,4 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-__version__ = "0.0.2"
+__version__ = "0.0.3"


### PR DESCRIPTION
Summary: During the conversation with Mootaz today, it just came to my realization that we haven't been making new release for PPL Bench for more than a year, and there has been a lot of changes both on our side, and on our dependencies. In so far many of us has been installing PPL Bench from source to get the latest changes, but it'd be more convenient if users can get PPL Bench from PyPI without running into errors.

Differential Revision: D38062970

