### PR TITLE
JSON & Scripts to Streamline Bean Machine Benchmarking

### DIFF
--- a/bm_g_jsons/crowd_sourced_annotation.json
+++ b/bm_g_jsons/crowd_sourced_annotation.json
@@ -1,0 +1,27 @@
+{
+  "model": {
+    "class": "crowd_sourced_annotation.CrowdSourcedAnnotation",
+    "args": {
+      "n": 1000,
+      "k": 10,
+      "num_categories": 2,
+      "expected_correctness": 0.8,
+      "num_labels_per_item": 3,
+      "concentration": 10
+    }
+  },
+  "iterations": 1000,
+  "trials": 3,
+  "ppls": [
+    {
+      "name": "beanmachine.graph",
+      "inference": {
+        "class": "inference.NMC"
+      },
+      "legend": {"color": "green", "name": "bmgraph-NMC"}
+    }
+  ],
+  "save_samples": true,
+  "loglevels": {"pystan": "INFO", "pplbench": "INFO"},
+  "figures": {"generate_pll": true, "suffix": "png"}
+}

--- a/bm_g_jsons/logistic_regression.json
+++ b/bm_g_jsons/logistic_regression.json
@@ -1,0 +1,32 @@
+{
+  "model": {
+    "class": "logistic_regression.LogisticRegression",
+    "args": {"n": 2000, "k": 10, "rho": 3.0}
+  },
+  "iterations": 1500,
+  "trials": 3,
+  "ppls": [
+    {
+      "name": "beanmachine.graph",
+      "inference": {
+        "class": "inference.NMC"
+      },
+      "legend": {"color": "green", "name": "bmgraph-NMC"}
+    },
+    {
+      "name": "beanmachine.graph",
+      "inference": {
+        "class": "inference.GlobalMCMC",
+        "infer_args": {
+          "mass_matrix": true,
+          "multinomial_sampling": true
+        }
+      },
+      "legend": {"color": "purple", "name": "bmgraph-NUTS"}
+    }
+  
+  ],
+  "save_samples": true,
+  "loglevels": {"pystan": "INFO", "pplbench": "INFO"},
+  "figures": {"generate_pll": true, "suffix": "png"}
+}

--- a/bm_g_jsons/n_schools.json
+++ b/bm_g_jsons/n_schools.json
@@ -1,0 +1,31 @@
+{
+  "model": {
+    "class": "n_schools.NSchools",
+    "args": {"n": 2000, "num_states": 20, "num_districts_per_state": 10}
+  },
+  "iterations": 1500,
+  "trials": 3,
+  "ppls": [
+    {
+      "name": "beanmachine.graph",
+      "inference": {
+        "class": "inference.NMC"
+      },
+      "legend": {"color": "green", "name": "bmgraph-NMC"}
+    },
+    {
+      "name": "beanmachine.graph",
+      "inference": {
+        "class": "inference.GlobalMCMC",
+        "infer_args": {
+          "mass_matrix": true,
+          "multinomial_sampling": true
+        }
+      },
+      "legend": {"color": "purple", "name": "bmgraph-NUTS"}
+    }
+  ],
+  "save_samples": true,
+  "loglevels": {"pystan": "INFO", "pplbench": "INFO"},
+  "figures": {"generate_pll": true, "suffix": "png"}
+}

--- a/bm_g_jsons/run_benchmark
+++ b/bm_g_jsons/run_benchmark
@@ -1,0 +1,4 @@
+for i in *.json
+do
+buck run @mode/opt //beanmachine/benchmarks/pplbench:main -- $i
+done

--- a/bm_py_jsons/logistic_regression.json
+++ b/bm_py_jsons/logistic_regression.json
@@ -1,0 +1,85 @@
+{
+  "model": {
+    "class": "logistic_regression.LogisticRegression",
+    "args": {"n": 2000, "k": 10, "rho": 3.0}
+  },
+  "iterations": 1500,
+  "trials": 3,
+  "ppls": [
+    {
+      "name": "beanmachine",
+      "inference": {
+        "class": "inference.MCMC",
+        "infer_args": {
+          "algorithm": "CompositionalInference"
+        }
+      },
+      "legend": {"color": "purple", "name": "bm-comp"}
+    },
+    {
+      "name": "beanmachine",
+      "inference": {
+        "class": "inference.MCMC",
+        "infer_args": {
+          "algorithm": "SingleSiteNewtonianMonteCarlo"
+        }
+      },
+      "legend": {"color": "green", "name": "bm-s-NMC"}
+    },
+    {
+      "name": "beanmachine",
+      "inference": {
+        "class": "inference.MCMC",
+        "infer_args": {
+          "algorithm": "SingleSiteNoUTurnSampler"
+        }
+      },
+      "legend": {"color": "black", "name": "bm-s-NUTS"}
+    },
+    {
+      "name": "beanmachine",
+      "inference": {
+        "class": "inference.MCMC",
+        "infer_args": {
+          "algorithm": "SingleSiteHamiltonianMonteCarlo",
+          "trajectory_length": 0.0032
+        }
+      },
+      "legend": {"color": "yellow", "name": "bm-s-hmc"}
+    },
+    {
+      "name": "beanmachine",
+      "inference": {
+        "class": "inference.MCMC",
+        "infer_args": {
+          "algorithm": "SingleSiteAncestralMetropolisHastings"
+        }
+      },
+      "legend": {"color": "red", "name": "bm-s-mh"}
+    },
+    {
+      "name": "beanmachine",
+      "inference": {
+        "class": "inference.MCMC",
+        "infer_args": {
+          "algorithm": "GlobalHamiltonianMonteCarlo",
+          "trajectory_length": 0.0032
+        }
+      },
+      "legend": {"color": "orange", "name": "bm-g-hmc"}
+    },
+    {
+      "name": "beanmachine",
+      "inference": {
+        "class": "inference.MCMC",
+        "infer_args": {
+          "algorithm": "GlobalNoUTurnSampler"
+        }
+      },
+      "legend": {"color": "blue", "name": "bm-g-nuts"}
+    }
+  ],
+  "save_samples": true,
+  "loglevels": {"pystan": "INFO", "pplbench": "INFO"},
+  "figures": {"generate_pll": true, "suffix": "png"}
+}

--- a/bm_py_jsons/n_schools.json
+++ b/bm_py_jsons/n_schools.json
@@ -1,0 +1,85 @@
+{
+  "model": {
+    "class": "n_schools.NSchools",
+    "args": {"n": 2000, "num_states": 20, "num_districts_per_state": 10}
+  },
+  "iterations": 1500,
+  "trials": 3,
+  "ppls": [
+    {
+      "name": "beanmachine",
+      "inference": {
+        "class": "inference.MCMC",
+        "infer_args": {
+          "algorithm": "CompositionalInference"
+        }
+      },
+      "legend": {"color": "purple", "name": "bm-comp"}
+    },
+    {
+      "name": "beanmachine",
+      "inference": {
+        "class": "inference.MCMC",
+        "infer_args": {
+          "algorithm": "SingleSiteNewtonianMonteCarlo"
+        }
+      },
+      "legend": {"color": "green", "name": "bm-s-NMC"}
+    },
+    {
+      "name": "beanmachine",
+      "inference": {
+        "class": "inference.MCMC",
+        "infer_args": {
+          "algorithm": "SingleSiteNoUTurnSampler"
+        }
+      },
+      "legend": {"color": "black", "name": "bm-s-NUTS"}
+    },
+    {
+      "name": "beanmachine",
+      "inference": {
+        "class": "inference.MCMC",
+        "infer_args": {
+          "algorithm": "SingleSiteHamiltonianMonteCarlo",
+          "trajectory_length": 0.0032
+        }
+      },
+      "legend": {"color": "yellow", "name": "bm-s-hmc"}
+    },
+    {
+      "name": "beanmachine",
+      "inference": {
+        "class": "inference.MCMC",
+        "infer_args": {
+          "algorithm": "SingleSiteAncestralMetropolisHastings"
+        }
+      },
+      "legend": {"color": "red", "name": "bm-s-mh"}
+    },
+    {
+      "name": "beanmachine",
+      "inference": {
+        "class": "inference.MCMC",
+        "infer_args": {
+          "algorithm": "GlobalHamiltonianMonteCarlo",
+          "trajectory_length": 0.0032
+        }
+      },
+      "legend": {"color": "orange", "name": "bm-g-hmc"}
+    },
+    {
+      "name": "beanmachine",
+      "inference": {
+        "class": "inference.MCMC",
+        "infer_args": {
+          "algorithm": "GlobalNoUTurnSampler"
+        }
+      },
+      "legend": {"color": "blue", "name": "bm-g-nuts"}
+    }
+  ],
+  "save_samples": true,
+  "loglevels": {"pystan": "INFO", "pplbench": "INFO"},
+  "figures": {"generate_pll": true, "suffix": "png"}
+}

--- a/bm_py_jsons/noisy_or_topic.json
+++ b/bm_py_jsons/noisy_or_topic.json
@@ -1,0 +1,54 @@
+{
+  "model": {
+    "class": "noisy_or_topic.NoisyOrTopic",
+    "args": {
+      "n": 2,
+      "num_topics": 20,
+      "num_words": 200,
+      "avg_fanout": 10.0
+    }
+  },
+  "iterations": 2000,
+  "trials": 3,
+  "ppls": [
+    {
+      "name": "beanmachine",
+      "inference": {
+        "class": "inference.MCMC",
+        "infer_args": {
+          "algorithm": "CompositionalInference"
+        }
+      },
+      "legend": {"color": "purple", "name": "bm-comp"}
+    },
+    {
+      "name": "beanmachine",
+      "inference": {
+        "class": "inference.MCMC",
+        "infer_args": {
+          "algorithm": "SingleSiteNewtonianMonteCarlo"
+        }
+      },
+      "legend": {"color": "green", "name": "bm-s-NMC"}
+    },
+    {
+      "name": "beanmachine",
+      "inference": {
+        "class": "inference.MCMC",
+        "infer_args": {
+          "algorithm": "SingleSiteAncestralMetropolisHastings"
+        }
+      },
+      "legend": {"color": "red", "name": "bm-s-mh"}
+    }
+  ],
+  "save_samples": true,
+  "loglevels": {
+    "pystan": "INFO",
+    "pplbench": "INFO"
+  },
+  "figures": {
+    "generate_pll": true,
+    "suffix": "png"
+  }
+}

--- a/bm_py_jsons/robust_regression.json
+++ b/bm_py_jsons/robust_regression.json
@@ -1,0 +1,83 @@
+{
+  "model": {
+    "class": "robust_regression.RobustRegression",
+    "args": {
+      "n": 2000,
+      "k": 10
+    }
+  },
+  "iterations": 1500,
+  "trials": 3,
+  "ppls": [
+    {
+      "name": "beanmachine",
+      "inference": {
+        "class": "inference.MCMC",
+        "infer_args": {
+          "algorithm": "CompositionalInference"
+        }
+      },
+      "legend": {"color": "purple", "name": "bm-comp"}
+    },
+    {
+      "name": "beanmachine",
+      "inference": {
+        "class": "inference.MCMC",
+        "infer_args": {
+          "algorithm": "SingleSiteNewtonianMonteCarlo"
+        }
+      },
+      "legend": {"color": "green", "name": "bm-s-NMC"}
+    },
+    {
+      "name": "beanmachine",
+      "inference": {
+        "class": "inference.MCMC",
+        "infer_args": {
+          "algorithm": "SingleSiteNoUTurnSampler"
+        }
+      },
+      "legend": {"color": "black", "name": "bm-s-NUTS"}
+    },
+    {
+      "name": "beanmachine",
+      "inference": {
+        "class": "inference.MCMC",
+        "infer_args": {
+          "algorithm": "SingleSiteAncestralMetropolisHastings"
+        }
+      },
+      "legend": {"color": "red", "name": "bm-s-mh"}
+    },
+    {
+      "name": "beanmachine",
+      "inference": {
+        "class": "inference.MCMC",
+        "infer_args": {
+          "algorithm": "GlobalHamiltonianMonteCarlo",
+          "trajectory_length": 0.0032
+        }
+      },
+      "legend": {"color": "orange", "name": "bm-g-hmc"}
+    },
+    {
+      "name": "beanmachine",
+      "inference": {
+        "class": "inference.MCMC",
+        "infer_args": {
+          "algorithm": "GlobalNoUTurnSampler"
+        }
+      },
+      "legend": {"color": "blue", "name": "bm-g-nuts"}
+    }
+  ],
+  "save_samples": true,
+  "loglevels": {
+    "pystan": "INFO",
+    "pplbench": "INFO"
+  },
+  "figures": {
+    "generate_pll": true,
+    "suffix": "png"
+  }
+}

--- a/bm_py_jsons/run_benchmark
+++ b/bm_py_jsons/run_benchmark
@@ -1,0 +1,4 @@
+for i in *.json
+do
+buck run @mode/opt //beanmachine/benchmarks/pplbench:main -- $i
+done


### PR DESCRIPTION
Summary: This set of files simplifies the running of the PPLBench benchmarks for BM-Python and BMG implementations. Prior to this diff, one had to manually update the json files to eliminate the runs that are not relevant to a study. The example JSON files are organized by benchmarks, but often a study is focused on a particular inference implementation. This diff provides a more streamlined approach that is oriented by the inference mechanism to simplify the process of running the benchmark and increase the convenience for end user. At some point, the parameters included in the JSON files will need to be tuned to be more approriate for the inference algorithm that is being tested. This work is left for a future iteration. This is a first stake in the ground that should be improved in the future.

Differential Revision: D38600089

